### PR TITLE
fix(analysis): make volatility/quality/charts run on Polars 1.20 (R3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,6 @@ ignore = ["E501"]
 "src/energex/main.py" = ["T201"]
 "src/energex/data_fetcher.py" = ["T201"]
 "src/energex/database.py" = ["T201"]  # print() -> structured logging pending (R10)
-# numpy import + dict()->literal cleanup land with the charts fix (R3).
-"src/energex/visualization/charts.py" = ["F821", "C408"]
 
 [tool.black]
 line-length = 100

--- a/src/energex/analysis/quality.py
+++ b/src/energex/analysis/quality.py
@@ -9,18 +9,17 @@ class DataQualityChecker:
         self.df = df
 
     def check_price_gaps(self, threshold_pct: float = 0.5) -> pl.DataFrame:
-        """
-        Detect significant price gaps between consecutive timestamps.
+        """Detect significant price gaps between consecutive bars.
+
         Args:
-            threshold_pct: Percentage change threshold to flag as gap
+            threshold_pct: percent move (e.g. 0.5 == 0.5%) flagged as a gap.
         """
         return (
             self.df.sort(["Symbol", "Datetime"])
-            .group_by("Symbol")
-            .agg(
+            .with_columns(
                 [
-                    pl.col("Close").pct_change().alias("price_change_pct"),
-                    pl.col("Datetime").diff().alias("time_gap"),
+                    (pl.col("Close").pct_change() * 100).over("Symbol").alias("price_change_pct"),
+                    pl.col("Datetime").diff().over("Symbol").alias("time_gap"),
                 ]
             )
             .filter(
@@ -30,87 +29,73 @@ class DataQualityChecker:
         )
 
     def check_volume_anomalies(self, z_score_threshold: float = 3.0) -> pl.DataFrame:
-        """
-        Detect unusual volume spikes using z-score.
-        """
+        """Detect unusual volume spikes using a rolling per-symbol z-score."""
         return (
-            self.df.group_by("Symbol")
-            .mutate(
+            self.df.sort(["Symbol", "Datetime"])
+            .with_columns(
                 [
-                    pl.col("Volume").rolling_mean(window_size=20).alias("avg_volume"),
-                    pl.col("Volume").rolling_std(window_size=20).alias("std_volume"),
+                    pl.col("Volume")
+                    .rolling_mean(window_size=20)
+                    .over("Symbol")
+                    .alias("avg_volume"),
+                    pl.col("Volume").rolling_std(window_size=20).over("Symbol").alias("std_volume"),
                 ]
             )
             .with_columns(
-                [
-                    ((pl.col("Volume") - pl.col("avg_volume")) / pl.col("std_volume")).alias(
-                        "volume_z_score"
-                    )
-                ]
+                ((pl.col("Volume") - pl.col("avg_volume")) / pl.col("std_volume")).alias(
+                    "volume_z_score"
+                )
             )
             .filter(pl.col("volume_z_score").abs() > z_score_threshold)
         )
 
     def check_price_reversals(self, threshold_pct: float = 1.0) -> pl.DataFrame:
-        """
-        Detect significant price reversals within short timeframes.
-        """
+        """Detect significant high-low range within a short rolling window, per symbol."""
         return (
             self.df.sort(["Symbol", "Datetime"])
-            .group_by("Symbol")
-            .mutate(
+            .with_columns(
                 [
-                    pl.col("High").rolling_max(window_size=5).alias("max_5min"),
-                    pl.col("Low").rolling_min(window_size=5).alias("min_5min"),
-                    ((pl.col("max_5min") - pl.col("min_5min")) / pl.col("min_5min") * 100).alias(
-                        "price_range_pct"
-                    ),
+                    pl.col("High").rolling_max(window_size=5).over("Symbol").alias("max_5min"),
+                    pl.col("Low").rolling_min(window_size=5).over("Symbol").alias("min_5min"),
                 ]
+            )
+            .with_columns(
+                ((pl.col("max_5min") - pl.col("min_5min")) / pl.col("min_5min") * 100).alias(
+                    "price_range_pct"
+                )
             )
             .filter(pl.col("price_range_pct") > threshold_pct)
         )
 
-    def check_tick_quality(self) -> dict:
-        """
-        Analyze overall data quality metrics.
-        """
-        metrics = {}
-
-        # Check for zero or negative prices
+    def check_tick_quality(self) -> dict[str, object]:
+        """Summarize overall data-quality metrics with scalar counts."""
         invalid_prices = self.df.filter(
             (pl.col("Close") <= 0)
             | (pl.col("High") <= 0)
             | (pl.col("Low") <= 0)
             | (pl.col("Open") <= 0)
-        ).count()
+        ).height
 
-        # Check OHLC consistency
         invalid_ohlc = self.df.filter(
             (pl.col("High") < pl.col("Low"))
             | (pl.col("Open") > pl.col("High"))
             | (pl.col("Open") < pl.col("Low"))
             | (pl.col("Close") > pl.col("High"))
             | (pl.col("Close") < pl.col("Low"))
-        ).count()
+        ).height
 
-        # Check timestamp consistency
-        time_gaps = (
+        large_time_gaps = (
             self.df.sort(["Symbol", "Datetime"])
-            .group_by("Symbol")
-            .agg([pl.col("Datetime").diff().alias("time_gap")])
+            .with_columns(pl.col("Datetime").diff().over("Symbol").alias("time_gap"))
             .filter(pl.col("time_gap") > timedelta(minutes=5))
-            .count()
+            .height
         )
 
-        metrics.update(
-            {
-                "invalid_prices": invalid_prices,
-                "invalid_ohlc": invalid_ohlc,
-                "large_time_gaps": time_gaps,
-                "total_records": len(self.df),
-                "symbols": self.df["Symbol"].unique().to_list(),
-                "date_range": [self.df["Datetime"].min(), self.df["Datetime"].max()],
-            }
-        )
-
-        return metrics
+        return {
+            "invalid_prices": invalid_prices,
+            "invalid_ohlc": invalid_ohlc,
+            "large_time_gaps": large_time_gaps,
+            "total_records": self.df.height,
+            "symbols": self.df["Symbol"].unique().to_list(),
+            "date_range": [self.df["Datetime"].min(), self.df["Datetime"].max()],
+        }

--- a/src/energex/analysis/volatility.py
+++ b/src/energex/analysis/volatility.py
@@ -3,95 +3,78 @@
 import numpy as np
 import polars as pl
 
+# Naive intraday annualization factor (1-min bars assumed 24h session).
+# NOTE: methodology correctness (5-min sampling, session-gap masking, calendar-based
+# annualization, Yang-Zhang) is addressed separately in ASSESSMENT R7; this module
+# only restores correct *execution* on the Polars 1.20 API (group_by has no .mutate;
+# use with_columns(expr.over('Symbol')) instead).
+_ANNUALIZE = float(np.sqrt(252 * 1440))
+
 
 class VolatilityAnalyzer:
     def __init__(self, df: pl.DataFrame):
         self.df = df
 
-    def calculate_realized_volatility(self, window_minutes: int = 30) -> pl.DataFrame:
-        """
-        Calculate realized volatility using log returns.
-        """
-        return (
-            self.df.sort(["Symbol", "Datetime"])
-            .group_by("Symbol")
-            .mutate(
-                [
-                    pl.col("Close")
-                    .log()
-                    .diff()
-                    .rolling_std(window_size=window_minutes)
-                    .mul(np.sqrt(252 * 1440))  # Annualize (252 days * 1440 minutes)
-                    .alias("realized_vol")
-                ]
-            )
+    def calculate_realized_volatility(
+        self, window_minutes: int = 30, df: pl.DataFrame | None = None
+    ) -> pl.DataFrame:
+        """Rolling realized volatility from log returns, computed per symbol."""
+        frame = self.df if df is None else df
+        return frame.sort(["Symbol", "Datetime"]).with_columns(
+            (pl.col("Close").log().diff().rolling_std(window_size=window_minutes) * _ANNUALIZE)
+            .over("Symbol")
+            .alias("realized_vol")
         )
 
-    def calculate_parkinson_volatility(self, window_minutes: int = 30) -> pl.DataFrame:
-        """
-        Calculate Parkinson volatility using high-low range.
-        """
-        return (
-            self.df.sort(["Symbol", "Datetime"])
-            .group_by("Symbol")
-            .mutate(
-                [
-                    (pl.col("High") / pl.col("Low"))
-                    .log()
-                    .pow(2)
-                    .rolling_mean(window_size=window_minutes)
-                    .mul(1 / (4 * np.log(2)))
-                    .sqrt()
-                    .mul(np.sqrt(252 * 1440))
-                    .alias("parkinson_vol")
-                ]
+    def calculate_parkinson_volatility(
+        self, window_minutes: int = 30, df: pl.DataFrame | None = None
+    ) -> pl.DataFrame:
+        """Parkinson high-low range volatility, computed per symbol."""
+        frame = self.df if df is None else df
+        return frame.sort(["Symbol", "Datetime"]).with_columns(
+            (
+                (pl.col("High") / pl.col("Low"))
+                .log()
+                .pow(2)
+                .rolling_mean(window_size=window_minutes)
+                .mul(1 / (4 * np.log(2)))
+                .sqrt()
+                .mul(_ANNUALIZE)
             )
+            .over("Symbol")
+            .alias("parkinson_vol")
         )
 
-    def calculate_garman_klass_volatility(self, window_minutes: int = 30) -> pl.DataFrame:
-        """
-        Calculate Garman-Klass volatility using OHLC prices.
-        """
-        return (
-            self.df.sort(["Symbol", "Datetime"])
-            .group_by("Symbol")
-            .mutate(
-                [
-                    (
-                        0.5 * (pl.col("High") / pl.col("Low")).log().pow(2)
-                        - (2 * np.log(2) - 1) * (pl.col("Close") / pl.col("Open")).log().pow(2)
-                    )
-                    .rolling_mean(window_size=window_minutes)
-                    .sqrt()
-                    .mul(np.sqrt(252 * 1440))
-                    .alias("garman_klass_vol")
-                ]
+    def calculate_garman_klass_volatility(
+        self, window_minutes: int = 30, df: pl.DataFrame | None = None
+    ) -> pl.DataFrame:
+        """Garman-Klass OHLC volatility, computed per symbol."""
+        frame = self.df if df is None else df
+        return frame.sort(["Symbol", "Datetime"]).with_columns(
+            (
+                (
+                    0.5 * (pl.col("High") / pl.col("Low")).log().pow(2)
+                    - (2 * np.log(2) - 1) * (pl.col("Close") / pl.col("Open")).log().pow(2)
+                )
+                .rolling_mean(window_size=window_minutes)
+                .sqrt()
+                .mul(_ANNUALIZE)
             )
+            .over("Symbol")
+            .alias("garman_klass_vol")
         )
 
     def calculate_volatility_metrics(self) -> pl.DataFrame:
-        """
-        Calculate comprehensive volatility metrics.
-        """
-        df = self.df.clone()
-
-        # Add all volatility measures
-        df = (
-            df.pipe(self.calculate_realized_volatility)
-            .pipe(self.calculate_parkinson_volatility)
-            .pipe(self.calculate_garman_klass_volatility)
-        )
-
-        # Add volatility ratios and spreads
-        df = df.with_columns(
+        """Compose all volatility measures plus ratios and intraday range."""
+        df = self.calculate_realized_volatility()
+        df = self.calculate_parkinson_volatility(df=df)
+        df = self.calculate_garman_klass_volatility(df=df)
+        return df.with_columns(
             [
                 (pl.col("parkinson_vol") / pl.col("realized_vol")).alias("vol_ratio_pk_rv"),
                 (pl.col("garman_klass_vol") / pl.col("realized_vol")).alias("vol_ratio_gk_rv"),
-                (pl.col("High") - pl.col("Low"))
-                .div(pl.col("Open"))
-                .mul(100)
-                .alias("intraday_range_pct"),
+                ((pl.col("High") - pl.col("Low")) / pl.col("Open") * 100).alias(
+                    "intraday_range_pct"
+                ),
             ]
         )
-
-        return df

--- a/src/energex/visualization/charts.py
+++ b/src/energex/visualization/charts.py
@@ -1,5 +1,6 @@
 # src/energex/visualization/charts.py
 
+import numpy as np
 import plotly.graph_objects as go
 import polars as pl
 from plotly.subplots import make_subplots
@@ -26,7 +27,7 @@ class MarketVisualizer:
 
         # Price chart with gaps highlighted
         fig.add_trace(
-            go.Scatter(x=df["Datetime"], y=df["Close"], name="Price", line=dict(color="blue")),
+            go.Scatter(x=df["Datetime"], y=df["Close"], name="Price", line={"color": "blue"}),
             row=1,
             col=1,
         )
@@ -57,9 +58,11 @@ class MarketVisualizer:
                 y=price_changes["price_change"],
                 name="Price Changes",
                 mode="lines+markers",
-                marker=dict(
-                    color=price_changes["price_change"].abs(), colorscale="RdYlBu", showscale=True
-                ),
+                marker={
+                    "color": price_changes["price_change"].abs(),
+                    "colorscale": "RdYlBu",
+                    "showscale": True,
+                },
             ),
             row=3,
             col=1,
@@ -127,7 +130,8 @@ class MarketVisualizer:
         fig.add_trace(
             go.Histogram(
                 y=df["Close"],
-                weights=df["Volume"],
+                x=df["Volume"],
+                histfunc="sum",
                 nbinsy=50,
                 name="Volume Profile",
                 orientation="h",
@@ -205,11 +209,11 @@ class MarketVisualizer:
                 x=latest["expiry"],
                 y=latest["Close"],
                 mode="markers",
-                marker=dict(
-                    size=latest["Volume"],
-                    sizeref=2.0 * max(latest["Volume"]) / (40.0**2),
-                    sizemin=4,
-                ),
+                marker={
+                    "size": latest["Volume"],
+                    "sizeref": 2.0 * max(latest["Volume"]) / (40.0**2),
+                    "sizemin": 4,
+                },
                 name="Volume",
             )
         )

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,0 +1,16 @@
+"""Tests that the Plotly charts build without raising (R3)."""
+
+import plotly.graph_objects as go
+
+from energex.visualization.charts import MarketVisualizer
+
+
+def test_plot_price_quality_returns_figure(sample_ohlcv):
+    fig = MarketVisualizer(sample_ohlcv).plot_price_quality("CL=F")
+    assert isinstance(fig, go.Figure)
+
+
+def test_plot_volatility_analysis_returns_figure(sample_ohlcv):
+    # Previously raised NameError (numpy used but never imported).
+    fig = MarketVisualizer(sample_ohlcv).plot_volatility_analysis("CL=F")
+    assert isinstance(fig, go.Figure)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,68 @@
+"""Tests that data-quality checks run on Polars 1.20 and return correct types (R3)."""
+
+from datetime import datetime
+
+import polars as pl
+
+from energex.analysis.quality import DataQualityChecker
+
+
+def test_check_tick_quality_returns_scalar_counts(sample_ohlcv):
+    metrics = DataQualityChecker(sample_ohlcv).check_tick_quality()
+    assert isinstance(metrics["invalid_prices"], int)
+    assert isinstance(metrics["invalid_ohlc"], int)
+    assert isinstance(metrics["total_records"], int)
+    assert metrics["total_records"] == sample_ohlcv.height
+    # The sample frame is clean.
+    assert metrics["invalid_prices"] == 0
+    assert metrics["invalid_ohlc"] == 0
+
+
+def test_check_tick_quality_detects_ohlc_inconsistency():
+    df = pl.DataFrame(
+        {
+            "Datetime": [datetime(2024, 1, 1, 0, 0), datetime(2024, 1, 1, 0, 1)],
+            "Symbol": ["CL=F", "CL=F"],
+            "Open": [10.0, 10.0],
+            "High": [11.0, 9.0],  # second row: High < Low -> inconsistent
+            "Low": [9.0, 10.0],
+            "Close": [10.5, 9.5],
+            "Volume": [1, 1],
+        }
+    )
+    metrics = DataQualityChecker(df).check_tick_quality()
+    assert metrics["invalid_ohlc"] == 1
+
+
+def test_check_price_gaps_returns_dataframe(sample_ohlcv):
+    out = DataQualityChecker(sample_ohlcv).check_price_gaps(threshold_pct=0.5)
+    assert isinstance(out, pl.DataFrame)
+
+
+def test_check_price_gaps_threshold_is_percent():
+    # A +2% jump must be flagged at threshold_pct=1.0 but not at threshold_pct=5.0.
+    df = pl.DataFrame(
+        {
+            "Datetime": [datetime(2024, 1, 1, 0, 0), datetime(2024, 1, 1, 0, 1)],
+            "Symbol": ["CL=F", "CL=F"],
+            "Open": [100.0, 102.0],
+            "High": [100.0, 102.0],
+            "Low": [100.0, 102.0],
+            "Close": [100.0, 102.0],  # +2%
+            "Volume": [1, 1],
+        }
+    )
+    flagged_at_1 = DataQualityChecker(df).check_price_gaps(threshold_pct=1.0)
+    flagged_at_5 = DataQualityChecker(df).check_price_gaps(threshold_pct=5.0)
+    assert flagged_at_1.height == 1
+    assert flagged_at_5.height == 0
+
+
+def test_check_volume_anomalies_returns_dataframe(sample_ohlcv):
+    out = DataQualityChecker(sample_ohlcv).check_volume_anomalies()
+    assert isinstance(out, pl.DataFrame)
+
+
+def test_check_price_reversals_returns_dataframe(sample_ohlcv):
+    out = DataQualityChecker(sample_ohlcv).check_price_reversals()
+    assert isinstance(out, pl.DataFrame)

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -1,0 +1,48 @@
+"""Tests that the volatility estimators run on Polars 1.20 and isolate per symbol (R3)."""
+
+import polars as pl
+
+from energex.analysis.volatility import VolatilityAnalyzer
+
+
+def test_realized_volatility_adds_column_for_all_symbols(sample_ohlcv):
+    out = VolatilityAnalyzer(sample_ohlcv).calculate_realized_volatility(window_minutes=5)
+    assert "realized_vol" in out.columns
+    assert out.height == sample_ohlcv.height
+    assert set(out["Symbol"].unique()) == {"CL=F", "NG=F"}
+
+
+def test_parkinson_volatility_runs(sample_ohlcv):
+    out = VolatilityAnalyzer(sample_ohlcv).calculate_parkinson_volatility(window_minutes=5)
+    assert "parkinson_vol" in out.columns
+    assert out.height == sample_ohlcv.height
+
+
+def test_garman_klass_volatility_runs(sample_ohlcv):
+    out = VolatilityAnalyzer(sample_ohlcv).calculate_garman_klass_volatility(window_minutes=5)
+    assert "garman_klass_vol" in out.columns
+
+
+def test_volatility_metrics_combines_all_measures(sample_ohlcv):
+    out = VolatilityAnalyzer(sample_ohlcv).calculate_volatility_metrics()
+    for col in (
+        "realized_vol",
+        "parkinson_vol",
+        "garman_klass_vol",
+        "vol_ratio_pk_rv",
+        "vol_ratio_gk_rv",
+        "intraday_range_pct",
+    ):
+        assert col in out.columns
+
+
+def test_rolling_window_resets_per_symbol(sample_ohlcv):
+    # With .over('Symbol') the rolling window must restart for each symbol, so the
+    # first NG=F row cannot inherit CL=F's tail.
+    out = (
+        VolatilityAnalyzer(sample_ohlcv)
+        .calculate_realized_volatility(window_minutes=10)
+        .sort(["Symbol", "Datetime"])
+    )
+    ng_first = out.filter(pl.col("Symbol") == "NG=F").sort("Datetime")["realized_vol"][0]
+    assert ng_first is None


### PR DESCRIPTION
**Phase 1 of the remediation roadmap (ASSESSMENT.md §4).** The headline analytics were dead-on-arrival: every per-symbol computation called `GroupBy.mutate()`, which does not exist in Polars.

### Fix
- **volatility.py** — `with_columns(expr.over('Symbol'))` instead of `.mutate`; all three estimators and `calculate_volatility_metrics` now run (the latter's `.pipe` previously bound the DataFrame to `window_minutes`). *Estimator math is unchanged here — methodology correctness (5-min RV, gap masking, annualization, Yang-Zhang) is **R7**, noted in code.*
- **quality.py** — gap/volume/reversal/tick checks run; gap & tick checks build per-row `.over()` columns instead of list-dtype aggregates (the old `SchemaError`); `.count()` → `.height` (was returning a DataFrame); **pct-change threshold is now percent** (was off by 100×).
- **charts.py** — `import numpy` (`plot_volatility_analysis` raised `NameError`); replace invalid `go.Histogram(weights=...)` with `x=Volume, histfunc='sum'`; `dict()`→literals. Removes the temporary charts lint ignore.

### Tests (TDD, 13 new)
Estimators add expected columns and **reset the rolling window per symbol**; quality returns scalar counts, treats the threshold as a percent, and detects an injected `High<Low`; both charts build into `go.Figure`. Full suite **43 green**; ruff + mypy clean on touched files.

Note: `plot_futures_curve`/`FuturesAnalyzer` still reference a nonexistent `expiry` column — those are gated in the next PR (**R4**).