### PR TITLE
fix(futures): gate expiry-dependent analytics until the data model (R4)

### DIFF
--- a/src/energex/analysis/futures.py
+++ b/src/energex/analysis/futures.py
@@ -2,21 +2,32 @@
 
 import polars as pl
 
+# These analytics require a real contract-month/expiry data model (and a spot leg /
+# risk-free curve) that the current single-table, continuous-front-month schema does
+# not provide. They are gated until that model lands (ASSESSMENT R8) so they fail
+# clearly instead of crashing on a missing 'expiry' column or invalid Polars APIs.
+_NEEDS_CONTRACT_MODEL = (
+    "{name} requires a contract-month/expiry data model (dated contracts, and for "
+    "carry/implied-rate a spot leg + risk-free curve). The store only holds continuous "
+    "front-month proxies (CL=F/BZ=F/NG=F). See ASSESSMENT.md R8."
+)
+
 
 class FuturesAnalyzer:
     def __init__(self, df: pl.DataFrame):
         self.df = df
 
     def calculate_term_structure(self, front_month: str, back_month: str) -> pl.DataFrame:
+        """Spread between two symbols aligned on Datetime.
+
+        NOTE: with only continuous front-month proxies stored, this is an
+        inter-instrument spread, not a true single-curve term structure (which needs
+        multiple dated contract months at the same instant — ASSESSMENT R8).
         """
-        Calculate futures term structure and spreads.
-        """
-        # Assuming df contains data for multiple contract months
         front = self.df.filter(pl.col("Symbol") == front_month)
         back = self.df.filter(pl.col("Symbol") == back_month)
 
-        # Join and calculate spreads
-        spreads = front.join(back, on="Datetime", suffix="_back").with_columns(
+        return front.join(back, on="Datetime", suffix="_back").with_columns(
             [
                 (pl.col("Close") - pl.col("Close_back")).alias("spread"),
                 ((pl.col("Close") - pl.col("Close_back")) / pl.col("Close_back") * 100).alias(
@@ -26,16 +37,17 @@ class FuturesAnalyzer:
             ]
         )
 
-        return spreads
-
     def calculate_basis_risk(self, spot_symbol: str, futures_symbol: str) -> pl.DataFrame:
-        """
-        Calculate basis risk between spot and futures prices.
+        """Difference between two symbols aligned on Datetime.
+
+        NOTE: a true basis needs a real cash/spot series (e.g. EIA/FRED) which is not
+        ingested yet; passing two futures proxies gives an inter-instrument spread,
+        not spot-vs-futures basis (ASSESSMENT R8).
         """
         spot = self.df.filter(pl.col("Symbol") == spot_symbol)
         futures = self.df.filter(pl.col("Symbol") == futures_symbol)
 
-        basis = spot.join(futures, on="Datetime", suffix="_futures").with_columns(
+        return spot.join(futures, on="Datetime", suffix="_futures").with_columns(
             [
                 (pl.col("Close") - pl.col("Close_futures")).alias("basis"),
                 ((pl.col("Close") - pl.col("Close_futures")) / pl.col("Close_futures") * 100).alias(
@@ -44,73 +56,18 @@ class FuturesAnalyzer:
             ]
         )
 
-        return basis
-
     def analyze_roll_yield(
         self, front_month: str, back_month: str, window_minutes: int = 30
     ) -> pl.DataFrame:
-        """
-        Analyze roll yield between futures contracts.
-        """
-        spreads = self.calculate_term_structure(front_month, back_month)
-
-        roll_metrics = spreads.with_columns(
-            [
-                # Annualized roll yield
-                (
-                    (-pl.col("spread_pct") / 100)
-                    * (365 / (pl.col("expiry_back") - pl.col("expiry")).days)
-                    * 100
-                ).alias("roll_yield_annual"),
-                # Roll momentum
-                pl.col("spread")
-                .diff()
-                .rolling_mean(window_size=window_minutes)
-                .alias("roll_momentum"),
-                # Roll volatility
-                pl.col("spread").rolling_std(window_size=window_minutes).alias("roll_volatility"),
-            ]
-        )
-
-        return roll_metrics
+        """Annualized roll yield — gated (needs contract expiries)."""
+        raise NotImplementedError(_NEEDS_CONTRACT_MODEL.format(name="analyze_roll_yield"))
 
     def analyze_futures_curve(self, symbols: list[str]) -> pl.DataFrame:
-        """
-        Analyze the entire futures curve.
-        """
-        # Get latest prices for all contract months
-        latest = self.df.filter(pl.col("Symbol").is_in(symbols)).group_by("Symbol").tail(1)
-
-        # Calculate curve metrics
-        curve = latest.sort("expiry").with_columns(
-            [
-                pl.col("Close").diff().alias("curve_spread"),
-                pl.col("Close").pct_change().alias("curve_return"),
-                pl.col("Volume").alias("curve_volume"),
-            ]
-        )
-
-        return curve
+        """Cross-sectional curve by expiry — gated (needs contract expiries)."""
+        raise NotImplementedError(_NEEDS_CONTRACT_MODEL.format(name="analyze_futures_curve"))
 
     def calculate_implied_rates(
         self, spot_symbol: str, futures_symbol: str, risk_free_rate: float
     ) -> pl.DataFrame:
-        """
-        Calculate implied interest rates from futures-spot relationship.
-        """
-        basis = self.calculate_basis_risk(spot_symbol, futures_symbol)
-
-        implied = basis.with_columns(
-            [
-                # Implied rate calculation
-                (
-                    pl.log(pl.col("Close_futures") / pl.col("Close"))
-                    * (365 / (pl.col("expiry") - pl.col("Datetime")).days)
-                    * 100
-                ).alias("implied_rate"),
-                # Rate spread
-                (pl.col("implied_rate") - risk_free_rate).alias("rate_spread"),
-            ]
-        )
-
-        return implied
+        """Implied net carry from F/S — gated (needs spot leg + expiries)."""
+        raise NotImplementedError(_NEEDS_CONTRACT_MODEL.format(name="calculate_implied_rates"))

--- a/src/energex/visualization/charts.py
+++ b/src/energex/visualization/charts.py
@@ -188,42 +188,8 @@ class MarketVisualizer:
         return fig
 
     def plot_futures_curve(self, symbols: list[str]) -> go.Figure:
-        """
-        Create futures curve visualization.
-        """
-        # Get latest prices for all contracts
-        latest = self.df.filter(pl.col("Symbol").is_in(symbols)).group_by("Symbol").tail(1)
-
-        fig = go.Figure()
-
-        # Plot current curve
-        fig.add_trace(
-            go.Scatter(
-                x=latest["expiry"], y=latest["Close"], mode="lines+markers", name="Futures Curve"
-            )
+        """Plot the futures curve by expiry — gated until the contract-month data
+        model exists (this needs an 'expiry' column the schema does not have; R8)."""
+        raise NotImplementedError(
+            "plot_futures_curve requires a contract-month/expiry data model (see ASSESSMENT.md R8)."
         )
-
-        # Add volume bubbles
-        fig.add_trace(
-            go.Scatter(
-                x=latest["expiry"],
-                y=latest["Close"],
-                mode="markers",
-                marker={
-                    "size": latest["Volume"],
-                    "sizeref": 2.0 * max(latest["Volume"]) / (40.0**2),
-                    "sizemin": 4,
-                },
-                name="Volume",
-            )
-        )
-
-        fig.update_layout(
-            title="Futures Curve Analysis",
-            xaxis_title="Expiry",
-            yaxis_title="Price",
-            height=600,
-            showlegend=True,
-        )
-
-        return fig

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,6 +1,7 @@
-"""Tests that the Plotly charts build without raising (R3)."""
+"""Tests that the Plotly charts build without raising (R3) + futures gating (R4)."""
 
 import plotly.graph_objects as go
+import pytest
 
 from energex.visualization.charts import MarketVisualizer
 
@@ -14,3 +15,9 @@ def test_plot_volatility_analysis_returns_figure(sample_ohlcv):
     # Previously raised NameError (numpy used but never imported).
     fig = MarketVisualizer(sample_ohlcv).plot_volatility_analysis("CL=F")
     assert isinstance(fig, go.Figure)
+
+
+def test_plot_futures_curve_gated_until_data_model(sample_ohlcv):
+    # Relies on an 'expiry' column that the schema does not have (R8).
+    with pytest.raises(NotImplementedError):
+        MarketVisualizer(sample_ohlcv).plot_futures_curve(["CL=F", "NG=F"])

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -1,0 +1,32 @@
+"""Tests for FuturesAnalyzer: working spreads + gated expiry-dependent methods (R4)."""
+
+import pytest
+
+from energex.analysis.futures import FuturesAnalyzer
+
+
+def test_term_structure_computes_cross_symbol_spread(sample_ohlcv):
+    out = FuturesAnalyzer(sample_ohlcv).calculate_term_structure("CL=F", "NG=F")
+    assert "spread" in out.columns
+    assert out.height > 0
+
+
+def test_basis_risk_computes_spread(sample_ohlcv):
+    out = FuturesAnalyzer(sample_ohlcv).calculate_basis_risk("CL=F", "NG=F")
+    assert "basis" in out.columns
+    assert out.height > 0
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda a: a.analyze_roll_yield("CL=F", "NG=F"),
+        lambda a: a.analyze_futures_curve(["CL=F", "NG=F"]),
+        lambda a: a.calculate_implied_rates("CL=F", "NG=F", 0.05),
+    ],
+)
+def test_expiry_dependent_methods_raise_not_implemented(sample_ohlcv, call):
+    # These require a contract-month/expiry data model (R8) that does not exist yet;
+    # they must fail clearly rather than crash deep in Polars on a missing column.
+    with pytest.raises(NotImplementedError):
+        call(FuturesAnalyzer(sample_ohlcv))


### PR DESCRIPTION
**Phase 1 of the remediation roadmap (ASSESSMENT.md §4).** `FuturesAnalyzer.analyze_roll_yield` / `analyze_futures_curve` / `calculate_implied_rates` and `MarketVisualizer.plot_futures_curve` referenced a nonexistent `expiry` column (plus invalid `.days`/`pl.log`), crashing deep in Polars.

### Fix
- Gate those four methods with a clear `NotImplementedError` pointing to the contract-month data model (**R8**), so they fail honestly instead of crashing on a missing column.
- Keep `calculate_term_structure` / `calculate_basis_risk` (they run), but document them as **inter-instrument spreads** — a true single-curve term structure / spot basis needs dated contracts + a real spot leg.

### Tests (TDD)
Gated methods raise `NotImplementedError`; the two spread methods still compute a cross-symbol spread. Full suite **49 green**; ruff + mypy clean on touched files.