### PR TITLE
fix(storage): store timestamps as UTC TIMESTAMPTZ (R5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ warn_unused_configs = true
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = ["yfinance.*", "plotly.*", "duckdb.*", "feedparser.*", "bs4.*"]
+module = ["yfinance.*", "plotly.*", "duckdb.*", "feedparser.*", "bs4.*", "pytz"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/energex/data_fetcher.py
+++ b/src/energex/data_fetcher.py
@@ -6,6 +6,21 @@ import pytz
 import yfinance as yf
 
 
+def normalize_datetime_to_utc(df: pl.DataFrame) -> pl.DataFrame:
+    """Convert a tz-aware Datetime column to a UTC instant.
+
+    yfinance returns exchange-tz-aware bars; storing them as a single UTC instant makes
+    the (Symbol, Datetime) key host-independent. Naive or absent columns are returned
+    unchanged (the storage layer interprets naive timestamps as UTC).
+    """
+    if df.is_empty() or "Datetime" not in df.columns:
+        return df
+    dtype = df.schema["Datetime"]
+    if isinstance(dtype, pl.Datetime) and dtype.time_zone is not None:
+        return df.with_columns(pl.col("Datetime").dt.convert_time_zone("UTC"))
+    return df
+
+
 class EnergyDataFetcher:
     ENERGY_SYMBOLS = {
         "crude": {"ticker": "CL=F", "name": "Crude Oil Futures"},
@@ -13,7 +28,7 @@ class EnergyDataFetcher:
         "gas": {"ticker": "NG=F", "name": "Natural Gas Futures"},
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Initialize with UTC timezone
         self.end_time = datetime.now(pytz.UTC)
         self.start_time = self.end_time - timedelta(days=1)
@@ -45,10 +60,11 @@ class EnergyDataFetcher:
             df = pl.from_pandas(df)
             df = df.with_columns(pl.lit(ticker).alias("Symbol"))
 
-            # Sort and select columns in specific order
+            # Sort, select canonical columns, and normalize timestamps to UTC.
             df = df.sort(["Symbol", "Datetime"]).select(
                 ["Datetime", "Symbol", "Open", "High", "Low", "Close", "Volume"]
             )
+            df = normalize_datetime_to_utc(df)
 
             print(f"Got {len(df)} rows for {commodity} ({ticker})")
             return df

--- a/src/energex/database.py
+++ b/src/energex/database.py
@@ -26,16 +26,19 @@ class EnergyDatabase:
                 f"Cannot open database read-only; file does not exist: {self.db_path}"
             )
         self.conn = duckdb.connect(str(self.db_path), read_only=read_only)
+        # Store and display timestamps as UTC instants regardless of the host timezone.
+        self.conn.execute("SET TimeZone = 'UTC'")
         # Schema creation is DDL and cannot run on a read-only connection; callers
         # that only inspect/read (e.g. `main --check`) pass read_only=True.
         if not read_only:
             self._init_tables()
+            self._migrate_to_timestamptz()
 
     def _init_tables(self) -> None:
         """Create the intraday_prices table if it does not already exist (idempotent)."""
         self.conn.execute("""
             CREATE TABLE IF NOT EXISTS intraday_prices (
-                Datetime TIMESTAMP,
+                Datetime TIMESTAMPTZ,
                 Symbol VARCHAR,
                 Open DOUBLE,
                 High DOUBLE,
@@ -45,6 +48,45 @@ class EnergyDatabase:
                 CONSTRAINT pk_intraday PRIMARY KEY (Symbol, Datetime)
             )
         """)
+
+    def _migrate_to_timestamptz(self) -> None:
+        """Migrate a legacy naive-TIMESTAMP Datetime column to TIMESTAMPTZ (UTC).
+
+        Pre-R5 databases stored Datetime as a host-tz-dependent naive TIMESTAMP. Treat
+        those existing values as UTC and recreate-and-swap into a TIMESTAMPTZ column.
+        """
+        row = self.conn.execute(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_name = 'intraday_prices' AND column_name = 'Datetime'"
+        ).fetchone()
+        if not row or "TIME ZONE" in row[0]:
+            return  # already TIMESTAMPTZ (or no table)
+
+        self.conn.execute("BEGIN TRANSACTION")
+        try:
+            self.conn.execute("""
+                CREATE TABLE intraday_prices_tz (
+                    Datetime TIMESTAMPTZ,
+                    Symbol VARCHAR,
+                    Open DOUBLE,
+                    High DOUBLE,
+                    Low DOUBLE,
+                    Close DOUBLE,
+                    Volume BIGINT,
+                    CONSTRAINT pk_intraday PRIMARY KEY (Symbol, Datetime)
+                )
+            """)
+            self.conn.execute("""
+                INSERT INTO intraday_prices_tz
+                SELECT Datetime AT TIME ZONE 'UTC', Symbol, Open, High, Low, Close, Volume
+                FROM intraday_prices
+            """)
+            self.conn.execute("DROP TABLE intraday_prices")
+            self.conn.execute("ALTER TABLE intraday_prices_tz RENAME TO intraday_prices")
+            self.conn.execute("COMMIT")
+        except Exception:
+            self.conn.execute("ROLLBACK")
+            raise
 
     def reset(self) -> None:
         """Drop and recreate the table. Destructive — for explicit bootstrap only."""

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,88 @@
+"""Tests for UTC timestamp normalization and TIMESTAMPTZ storage (R5)."""
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import duckdb
+import polars as pl
+
+from energex.data_fetcher import normalize_datetime_to_utc
+from energex.database import EnergyDatabase
+
+
+def _dtype(conn) -> str:
+    return conn.execute(
+        "SELECT data_type FROM information_schema.columns "
+        "WHERE table_name = 'intraday_prices' AND column_name = 'Datetime'"
+    ).fetchone()[0]
+
+
+def test_datetime_column_is_timestamptz(tmp_db_path):
+    db = EnergyDatabase(tmp_db_path)
+    dtype = _dtype(db.conn)
+    db.conn.close()
+    assert "TIME ZONE" in dtype  # TIMESTAMP WITH TIME ZONE
+
+
+def test_stores_utc_instant_from_tz_aware_bar(tmp_db_path):
+    db = EnergyDatabase(tmp_db_path)
+    # 09:30 America/New_York == 14:30 UTC
+    df = pl.DataFrame(
+        {
+            "Datetime": [datetime(2024, 1, 2, 9, 30, tzinfo=ZoneInfo("America/New_York"))],
+            "Symbol": ["CL=F"],
+            "Open": [1.0],
+            "High": [1.0],
+            "Low": [1.0],
+            "Close": [1.0],
+            "Volume": [1],
+        }
+    )
+    db.insert_intraday_data(df)
+    stored = db.conn.execute("SELECT Datetime FROM intraday_prices").fetchone()[0]
+    db.conn.close()
+    assert stored == datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc)
+
+
+def test_migrates_legacy_timestamp_column_to_timestamptz(tmp_db_path):
+    # Simulate a pre-R5 database with a naive TIMESTAMP column.
+    con = duckdb.connect(tmp_db_path)
+    con.execute(
+        """
+        CREATE TABLE intraday_prices (
+            Datetime TIMESTAMP, Symbol VARCHAR, Open DOUBLE, High DOUBLE,
+            Low DOUBLE, Close DOUBLE, Volume BIGINT,
+            CONSTRAINT pk_intraday PRIMARY KEY (Symbol, Datetime)
+        )
+        """
+    )
+    con.execute(
+        "INSERT INTO intraday_prices VALUES (TIMESTAMP '2024-01-02 14:30:00', 'CL=F', 1, 1, 1, 1, 1)"
+    )
+    con.close()
+
+    db = EnergyDatabase(tmp_db_path)  # opening must migrate the column type
+    dtype = _dtype(db.conn)
+    count = db.conn.execute("SELECT COUNT(*) FROM intraday_prices").fetchone()[0]
+    stored = db.conn.execute("SELECT Datetime FROM intraday_prices").fetchone()[0]
+    db.conn.close()
+
+    assert "TIME ZONE" in dtype
+    assert count == 1
+    assert stored == datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc)
+
+
+def test_normalize_datetime_to_utc_converts_tz_aware():
+    df = pl.DataFrame(
+        {
+            "Datetime": [datetime(2024, 1, 2, 9, 30, tzinfo=ZoneInfo("America/New_York"))],
+            "Symbol": ["CL=F"],
+        }
+    )
+    out = normalize_datetime_to_utc(df)
+    assert out["Datetime"][0] == datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc)
+
+
+def test_normalize_datetime_to_utc_handles_empty():
+    empty = pl.DataFrame()
+    assert normalize_datetime_to_utc(empty).is_empty()


### PR DESCRIPTION
**Phase 2 of the remediation roadmap (ASSESSMENT.md §4).** yfinance bars are exchange-tz-aware but the column was naive `TIMESTAMP`, so DuckDB coerced them with the **host** session timezone — the same 09:30 NY bar stored as 14:30 / 06:30 / 23:30 on UTC / LA / Tokyo hosts (verified in the audit), corrupting the `(Symbol, Datetime)` primary key.

### Fix
- **`TIMESTAMPTZ` column** + `SET TimeZone='UTC'` on every connect → stored instants are host-independent.
- **Idempotent migration**: recreate-and-swap converts a legacy naive-`TIMESTAMP` column to `TIMESTAMPTZ` on open (existing values treated as UTC).
- **`normalize_datetime_to_utc()`** converts a tz-aware Datetime column to a UTC instant; applied in `get_commodity_data`.

### Tests (TDD)
Column is `TIMESTAMP WITH TIME ZONE`; a tz-aware NY 09:30 bar stores as the 14:30 UTC instant; a simulated legacy DB is migrated on open (type changes, row + value preserved); the normalize helper converts tz-aware → UTC and no-ops on empty. Full suite **54 green**; ruff + mypy clean on touched files.