### PR TITLE
fix(config): lock down env prefixes and secrets (R9)

### DIFF
--- a/src/energex/analysis/market_sentiment.py
+++ b/src/energex/analysis/market_sentiment.py
@@ -9,7 +9,7 @@ import polars as pl
 from energex.config import get_settings
 from energex.exceptions import AnalysisError, LLMProviderError
 from energex.llm_providers import BaseLLMProvider, LLMProviderFactory
-from energex.news_fetcher import NewsAPISource, NewsFetcher, RSSNewsSource
+from energex.news_fetcher import NewsAPISource, NewsFetcher, NewsSource, RSSNewsSource
 
 
 class MarketSentimentAnalyzer:
@@ -54,10 +54,11 @@ class MarketSentimentAnalyzer:
         # Initialize LLM provider
         try:
             provider_name = provider or self.settings.llm.provider
+            llm_key = self.settings.llm.api_key
             self.llm: BaseLLMProvider = LLMProviderFactory.create(
                 provider=provider_name,
                 model=self.settings.llm.model,
-                api_key=self.settings.llm.api_key,
+                api_key=llm_key.get_secret_value() if llm_key else None,
                 base_url=self.settings.llm.base_url,
             )
 
@@ -71,9 +72,10 @@ class MarketSentimentAnalyzer:
             self.llm = None  # type: ignore
 
         # Initialize news fetcher
-        news_sources = [RSSNewsSource()]
-        if self.settings.news.news_api_key:
-            news_sources.append(NewsAPISource(api_key=self.settings.news.news_api_key))
+        news_sources: list[NewsSource] = [RSSNewsSource()]
+        news_key = self.settings.news.news_api_key
+        if news_key is not None:
+            news_sources.append(NewsAPISource(api_key=news_key.get_secret_value()))
 
         self.news_fetcher = NewsFetcher(news_sources)
 

--- a/src/energex/config.py
+++ b/src/energex/config.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from energex.exceptions import ConfigurationError
@@ -16,32 +16,34 @@ class LLMConfig(BaseSettings):
         default="openai", description="LLM provider to use"
     )
     model: str = Field(default="gpt-4", description="Model name for the chosen provider")
-    api_key: str | None = Field(default=None, description="API key for the LLM provider")
+    api_key: SecretStr | None = Field(default=None, description="API key for the LLM provider")
     base_url: str | None = Field(default=None, description="Base URL for local LLM (Ollama)")
     requests_per_minute: int = Field(
         default=10, description="Maximum API requests per minute", gt=0
     )
     cache_ttl: int = Field(default=3600, description="Cache TTL for LLM responses in seconds", ge=0)
 
-    model_config = SettingsConfigDict(env_prefix="", case_sensitive=False)
-
-    @field_validator("provider")
-    @classmethod
-    def validate_provider(cls, v: str) -> str:
-        """Validate LLM provider choice."""
-        valid_providers = ["openai", "anthropic", "ollama"]
-        if v not in valid_providers:
-            raise ConfigurationError(f"Invalid LLM provider: {v}. Must be one of {valid_providers}")
-        return v
+    # Distinct prefix (was env_prefix="" which bound bare API_KEY/MODEL/BASE_URL and
+    # leaked foreign env vars into this config). validate_assignment re-checks overrides
+    # applied by EnergexSettings.model_post_init (e.g. an invalid provider).
+    model_config = SettingsConfigDict(
+        env_prefix="LLM_", case_sensitive=False, validate_assignment=True
+    )
 
 
 class NewsConfig(BaseSettings):
     """News API configuration."""
 
-    news_api_key: str | None = Field(default=None, description="NewsAPI.org API key")
-    alpha_vantage_key: str | None = Field(default=None, description="Alpha Vantage API key")
+    news_api_key: SecretStr | None = Field(
+        default=None, description="NewsAPI.org API key (env: NEWS_API_KEY)"
+    )
+    alpha_vantage_key: SecretStr | None = Field(
+        default=None, description="Alpha Vantage API key (env: ALPHA_VANTAGE_KEY)"
+    )
 
-    model_config = SettingsConfigDict(env_prefix="NEWS_", case_sensitive=False)
+    # env_prefix="" with descriptive field names gives the intuitive NEWS_API_KEY /
+    # ALPHA_VANTAGE_KEY (the previous NEWS_ prefix required NEWS_NEWS_API_KEY).
+    model_config = SettingsConfigDict(env_prefix="", case_sensitive=False)
 
 
 class DatabaseConfig(BaseSettings):
@@ -118,8 +120,8 @@ class EnergexSettings(BaseSettings):
     default_llm_model: str | None = Field(
         default=None, description="Override for default LLM model"
     )
-    openai_api_key: str | None = Field(default=None, description="OpenAI API key")
-    anthropic_api_key: str | None = Field(default=None, description="Anthropic API key")
+    openai_api_key: SecretStr | None = Field(default=None, description="OpenAI API key")
+    anthropic_api_key: SecretStr | None = Field(default=None, description="Anthropic API key")
     ollama_base_url: str | None = Field(default=None, description="Ollama base URL")
     llm_requests_per_minute: int | None = Field(default=None, description="LLM requests per minute")
     llm_cache_ttl_seconds: int | None = Field(default=None, description="LLM cache TTL")
@@ -129,23 +131,22 @@ class EnergexSettings(BaseSettings):
     )
 
     def model_post_init(self, __context: object) -> None:
-        """Apply overrides after initialization."""
-        # Apply top-level overrides to LLM config
-        if self.default_llm_provider:
-            self.llm.provider = self.default_llm_provider  # type: ignore
-        if self.default_llm_model:
+        """Apply top-level overrides to the LLM sub-config (validated on assignment)."""
+        if self.default_llm_provider is not None:
+            self.llm.provider = self.default_llm_provider  # type: ignore[assignment]
+        if self.default_llm_model is not None:
             self.llm.model = self.default_llm_model
-        if self.llm_requests_per_minute:
+        if self.llm_requests_per_minute is not None:
             self.llm.requests_per_minute = self.llm_requests_per_minute
-        if self.llm_cache_ttl_seconds:
+        if self.llm_cache_ttl_seconds is not None:
             self.llm.cache_ttl = self.llm_cache_ttl_seconds
 
-        # Set API key based on provider
-        if self.llm.provider == "openai" and self.openai_api_key:
+        # Set the API key / base URL for the active provider.
+        if self.llm.provider == "openai" and self.openai_api_key is not None:
             self.llm.api_key = self.openai_api_key
-        elif self.llm.provider == "anthropic" and self.anthropic_api_key:
+        elif self.llm.provider == "anthropic" and self.anthropic_api_key is not None:
             self.llm.api_key = self.anthropic_api_key
-        elif self.llm.provider == "ollama" and self.ollama_base_url:
+        elif self.llm.provider == "ollama" and self.ollama_base_url is not None:
             self.llm.base_url = self.ollama_base_url
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,40 @@
+"""Tests for config hardening: env prefixes, secret handling, validated overrides (R9)."""
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from energex.config import LLMConfig, NewsConfig
+
+
+def test_llm_config_reads_llm_prefixed_env(monkeypatch):
+    monkeypatch.setenv("LLM_MODEL", "custom-model")
+    assert LLMConfig().model == "custom-model"
+
+
+def test_bare_env_vars_do_not_inject_into_llm_config(monkeypatch):
+    # The previous env_prefix="" bound bare API_KEY / MODEL (secret injection).
+    monkeypatch.setenv("API_KEY", "leaked-key")
+    monkeypatch.setenv("MODEL", "evil-model")
+    cfg = LLMConfig()
+    assert cfg.api_key is None
+    assert cfg.model == "gpt-4"
+
+
+def test_api_key_is_secret_and_hidden_in_repr():
+    cfg = LLMConfig(api_key="sk-supersecret")
+    assert isinstance(cfg.api_key, SecretStr)
+    assert "sk-supersecret" not in repr(cfg)
+    assert cfg.api_key.get_secret_value() == "sk-supersecret"
+
+
+def test_invalid_provider_assignment_is_rejected():
+    cfg = LLMConfig()
+    with pytest.raises(ValidationError):
+        cfg.provider = "totally_invalid"  # type: ignore[assignment]
+
+
+def test_news_config_reads_intuitive_news_api_key(monkeypatch):
+    monkeypatch.setenv("NEWS_API_KEY", "news-k123")
+    cfg = NewsConfig()
+    assert cfg.news_api_key is not None
+    assert cfg.news_api_key.get_secret_value() == "news-k123"


### PR DESCRIPTION
**Phase 2 of the remediation roadmap (ASSESSMENT.md §4).**

### Problem (all confirmed in the audit)
- `LLMConfig(env_prefix="")` bound **bare** `API_KEY`/`MODEL`/`BASE_URL` → a foreign env var silently injected the wrong key/model/endpoint.
- API keys were plain `str` → printed verbatim in `repr`/logs/tracebacks.
- `model_post_init` assigned an override provider **without validation** (an invalid provider was accepted).
- `NewsConfig` required the counter-intuitive `NEWS_NEWS_API_KEY`.

### Fix
- `LLMConfig` → `env_prefix="LLM_"`; `api_key` is **`SecretStr`**; `validate_assignment=True` (invalid provider override now rejected); drop the redundant `validate_provider` (the `Literal` enforces choices).
- `NewsConfig` → `env_prefix=""` so **`NEWS_API_KEY`** / `ALPHA_VANTAGE_KEY` work; keys are `SecretStr`.
- `EnergexSettings`: OpenAI/Anthropic keys are `SecretStr`; `is not None` guards.
- `market_sentiment`: reveal secrets via `.get_secret_value()` only at point of use.

### Tests (TDD)
`LLM_` prefix read; bare `API_KEY`/`MODEL` no longer inject; `api_key` is `SecretStr` and absent from `repr`; invalid provider assignment raises; `NEWS_API_KEY` read intuitively. Full suite **59 green**; ruff clean.