### PR TITLE
feat(ingestion): structured logging + retry/timeout/error classification (R10)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,6 @@ ignore = ["E501"]
 "__init__.py" = ["F401"]
 "**/examples/*.py" = ["T201", "C408"]  # Allow print() and dict() in examples
 "**/test_*.py" = ["T201"]  # Allow print() in test files
-# --- TEMPORARY ignores, removed by the remediation PRs in ASSESSMENT.md ---
-# print() -> structured logging (R10): removed when logging is wired in.
-"src/energex/main.py" = ["T201"]
-"src/energex/data_fetcher.py" = ["T201"]
-"src/energex/database.py" = ["T201"]  # print() -> structured logging pending (R10)
 
 [tool.black]
 line-length = 100

--- a/src/energex/config.py
+++ b/src/energex/config.py
@@ -84,9 +84,9 @@ class DataFetchConfig(BaseSettings):
     """Data fetching configuration."""
 
     yfinance_timeout: int = Field(default=30, description="Yahoo Finance timeout in seconds")
-    data_fetch_retries: int = Field(default=3, description="Number of retry attempts", ge=0)
+    data_fetch_retries: int = Field(default=3, description="Number of download attempts", ge=0)
 
-    model_config = SettingsConfigDict(case_sensitive=False)
+    model_config = SettingsConfigDict(env_prefix="DATAFETCH_", case_sensitive=False)
 
 
 class AnalysisConfig(BaseSettings):

--- a/src/energex/data_fetcher.py
+++ b/src/energex/data_fetcher.py
@@ -1,9 +1,17 @@
 # src/energex/data_fetcher.py
+import logging
+import time
 from datetime import datetime, timedelta
+from typing import Any
 
 import polars as pl
 import pytz
 import yfinance as yf
+
+from energex.config import get_settings
+from energex.exceptions import DataFetchError
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_datetime_to_utc(df: pl.DataFrame) -> pl.DataFrame:
@@ -29,71 +37,79 @@ class EnergyDataFetcher:
     }
 
     def __init__(self) -> None:
-        # Initialize with UTC timezone
+        settings = get_settings()
+        self.timeout = settings.data_fetch.yfinance_timeout
+        self.retries = max(1, settings.data_fetch.data_fetch_retries)
         self.end_time = datetime.now(pytz.UTC)
         self.start_time = self.end_time - timedelta(days=1)
 
+    def _download_with_retry(self, ticker: str) -> Any:
+        """Download with a timeout and exponential backoff; raise on real failure."""
+        last_exc: Exception | None = None
+        for attempt in range(1, self.retries + 1):
+            try:
+                return yf.download(
+                    ticker,
+                    start=self.start_time,
+                    end=self.end_time,
+                    interval="1m",
+                    timeout=self.timeout,
+                )
+            except Exception as e:
+                last_exc = e
+                logger.warning(
+                    "Download attempt %d/%d for %s failed: %s", attempt, self.retries, ticker, e
+                )
+                if attempt < self.retries:
+                    time.sleep(min(2 ** (attempt - 1), 10))
+        raise DataFetchError(
+            f"Failed to download {ticker} after {self.retries} attempts"
+        ) from last_exc
+
     def get_commodity_data(self, commodity: str) -> pl.DataFrame:
-        """
-        Fetch intraday commodity data.
-        Args:
-            commodity: The commodity key (crude, brent, gas)
-        Returns:
-            Polars DataFrame with standardized columns
+        """Fetch intraday data for one commodity key (crude, brent, gas).
+
+        Returns an empty DataFrame only for a genuinely empty result; a real download
+        failure raises DataFetchError so callers can distinguish an outage from a
+        quiet (weekend/holiday) market.
         """
         ticker = self.ENERGY_SYMBOLS[commodity]["ticker"]
-        print(f"Downloading {commodity} ({ticker}) data...")
+        logger.info("Downloading %s (%s)", commodity, ticker)
 
-        try:
-            # Download data using the actual ticker symbol
-            data = yf.download(ticker, start=self.start_time, end=self.end_time, interval="1m")
-
-            if data.empty:
-                print(f"No data returned for {commodity} ({ticker})")
-                return pl.DataFrame()
-
-            # Reset index and handle multi-index columns
-            df = data.reset_index()
-            df.columns = [col[0] if isinstance(col, tuple) else col for col in df.columns]
-
-            # Convert to Polars DataFrame and add symbol
-            df = pl.from_pandas(df)
-            df = df.with_columns(pl.lit(ticker).alias("Symbol"))
-
-            # Sort, select canonical columns, and normalize timestamps to UTC.
-            df = df.sort(["Symbol", "Datetime"]).select(
-                ["Datetime", "Symbol", "Open", "High", "Low", "Close", "Volume"]
-            )
-            df = normalize_datetime_to_utc(df)
-
-            print(f"Got {len(df)} rows for {commodity} ({ticker})")
-            return df
-
-        except Exception as e:
-            print(f"Error downloading {commodity} ({ticker}): {str(e)}")
+        data = self._download_with_retry(ticker)
+        if data.empty:
+            logger.warning("No data returned for %s (%s)", commodity, ticker)
             return pl.DataFrame()
 
-    def fetch_all_commodities(self) -> pl.DataFrame:
-        """Fetch and combine data for all commodities."""
-        dfs = []
+        # Reset index and flatten any multi-index columns.
+        df = data.reset_index()
+        df.columns = [col[0] if isinstance(col, tuple) else col for col in df.columns]
 
+        df = pl.from_pandas(df).with_columns(pl.lit(ticker).alias("Symbol"))
+        df = df.sort(["Symbol", "Datetime"]).select(
+            ["Datetime", "Symbol", "Open", "High", "Low", "Close", "Volume"]
+        )
+        df = normalize_datetime_to_utc(df)
+
+        logger.info("Got %d rows for %s (%s)", len(df), commodity, ticker)
+        return df
+
+    def fetch_all_commodities(self) -> pl.DataFrame:
+        """Fetch and combine all commodities; a failed symbol is logged and skipped."""
+        dfs = []
         for commodity in self.ENERGY_SYMBOLS:
             try:
                 df = self.get_commodity_data(commodity)
                 if not df.is_empty():
                     dfs.append(df)
-            except Exception as e:
-                print(f"Error processing {commodity}: {str(e)}")
+            except DataFetchError as e:
+                logger.error("Failed to fetch %s: %s", commodity, e)
+                continue
 
         if not dfs:
             return pl.DataFrame()
 
-        # Combine all dataframes
-        combined_data = pl.concat(dfs)
-
-        # Clean and organize final dataset
-        final_data = combined_data.sort(["Symbol", "Datetime"]).select(
+        combined = pl.concat(dfs)
+        return combined.sort(["Symbol", "Datetime"]).select(
             ["Datetime", "Symbol", "Open", "High", "Low", "Close", "Volume"]
         )
-
-        return final_data

--- a/src/energex/database.py
+++ b/src/energex/database.py
@@ -1,10 +1,13 @@
 # src/energex/database.py
+import logging
 from pathlib import Path
 
 import duckdb
 import polars as pl
 
 from energex.exceptions import DatabaseError
+
+logger = logging.getLogger(__name__)
 
 
 class EnergyDatabase:
@@ -98,7 +101,7 @@ class EnergyDatabase:
     def insert_intraday_data(self, df: pl.DataFrame) -> None:
         """Idempotently upsert intraday OHLCV rows keyed by (Symbol, Datetime)."""
         if df.is_empty():
-            print("No data to insert")
+            logger.info("No data to insert")
             return
 
         missing = [c for c in self.COLUMNS if c not in df.columns]
@@ -125,8 +128,8 @@ class EnergyDatabase:
                     Volume = excluded.Volume
             """)
             self.conn.execute("COMMIT")
-            print(f"Upserted {len(df)} rows")
+            logger.info("Upserted %d rows", len(df))
         except Exception as e:
             self.conn.execute("ROLLBACK")
-            print(f"Error inserting data: {e}")
+            logger.error("Error inserting data: %s", e)
             raise

--- a/src/energex/main.py
+++ b/src/energex/main.py
@@ -1,9 +1,14 @@
 # src/energex/main.py
 import argparse
+import logging
 from datetime import datetime
 
+from energex.config import get_settings
 from energex.data_fetcher import EnergyDataFetcher
 from energex.database import EnergyDatabase
+from energex.logging_config import setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def update_intraday_data(db_path: str = "energy.db") -> None:
@@ -11,35 +16,29 @@ def update_intraday_data(db_path: str = "energy.db") -> None:
     db = EnergyDatabase(db_path)
     fetcher = EnergyDataFetcher()
 
-    print(f"\nStarting intraday data update at {datetime.now()}")
+    logger.info("Starting intraday data update at %s", datetime.now())
 
-    successful = []
-    failed = []
+    successful: list[str] = []
+    failed: list[tuple[str, str]] = []
 
     for symbol in fetcher.ENERGY_SYMBOLS:
         try:
-            print(f"\nProcessing {symbol}...")
+            logger.info("Processing %s", symbol)
             df = fetcher.get_commodity_data(symbol)
-
             if not df.is_empty():
                 db.insert_intraday_data(df)
                 successful.append(symbol)
             else:
                 failed.append((symbol, "No data returned"))
-
         except Exception as e:
-            print(f"Error processing {symbol}: {str(e)}")
+            logger.error("Error processing %s: %s", symbol, e)
             failed.append((symbol, str(e)))
 
-    # Print summary
-    print("\nUpdate Summary:")
-    print(f"Successfully processed: {len(successful)} symbols")
+    logger.info("Update complete: %d succeeded, %d failed", len(successful), len(failed))
     if successful:
-        print("Successful symbols:", ", ".join(successful))
-    if failed:
-        print("\nFailed symbols:")
-        for symbol, error in failed:
-            print(f"- {symbol}: {error}")
+        logger.info("Successful symbols: %s", ", ".join(successful))
+    for symbol, error in failed:
+        logger.warning("Failed symbol %s: %s", symbol, error)
 
 
 def check_schema(db_path: str = "energy.db") -> list[tuple[object, ...]]:
@@ -60,13 +59,20 @@ def reset_database(db_path: str = "energy.db") -> None:
     db = EnergyDatabase(db_path)
     try:
         db.reset()
-        print(f"Reset database at {db_path}")
+        logger.info("Reset database at %s", db_path)
     finally:
         db.conn.close()
 
 
 def main() -> None:
     """Main entry point."""
+    settings = get_settings()
+    setup_logging(
+        log_level=settings.logging.log_level,
+        log_file=settings.logging.log_file,
+        enable_console=settings.logging.log_enable_console,
+    )
+
     parser = argparse.ArgumentParser(description="Energy commodity data collector")
     parser.add_argument(
         "--check", action="store_true", help="Inspect the database schema (read-only)"
@@ -81,7 +87,7 @@ def main() -> None:
 
     if args.check:
         for row in check_schema():
-            print(row)
+            logger.info("%s", row)
     elif args.reset:
         reset_database()
     else:

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -1,0 +1,97 @@
+"""Tests for ingestion resilience: retries, error classification, logging (R10)."""
+
+import logging
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from energex import data_fetcher as df_mod
+from energex.data_fetcher import EnergyDataFetcher
+from energex.exceptions import DataFetchError
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    # Keep retry/backoff tests fast.
+    monkeypatch.setattr(df_mod.time, "sleep", lambda *_a, **_k: None)
+
+
+def _fetcher(retries: int = 3) -> EnergyDataFetcher:
+    f = EnergyDataFetcher()
+    f.retries = retries
+    f.timeout = 5
+    return f
+
+
+def test_raises_datafetcherror_after_exhausting_retries(monkeypatch):
+    calls = {"n": 0}
+
+    def boom(*_a, **_k):
+        calls["n"] += 1
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(df_mod.yf, "download", boom)
+    with pytest.raises(DataFetchError):
+        _fetcher(retries=3).get_commodity_data("crude")
+    assert calls["n"] == 3  # all attempts used
+
+
+def test_empty_result_returns_empty_frame_without_raising(monkeypatch):
+    monkeypatch.setattr(df_mod.yf, "download", lambda *_a, **_k: pd.DataFrame())
+    out = _fetcher().get_commodity_data("crude")
+    assert isinstance(out, pl.DataFrame)
+    assert out.is_empty()
+
+
+def test_retries_then_succeeds(monkeypatch):
+    state = {"n": 0}
+    pdf = pd.DataFrame(
+        {"Open": [75.0], "High": [76.0], "Low": [74.0], "Close": [75.5], "Volume": [1000]},
+        index=pd.DatetimeIndex(["2024-01-02 14:30"], name="Datetime"),
+    )
+
+    def flaky(*_a, **_k):
+        state["n"] += 1
+        if state["n"] == 1:
+            raise RuntimeError("transient")
+        return pdf
+
+    monkeypatch.setattr(df_mod.yf, "download", flaky)
+    out = _fetcher(retries=3).get_commodity_data("crude")
+    assert state["n"] == 2
+    assert out.height == 1
+    assert out["Symbol"][0] == "CL=F"
+
+
+def test_fetch_all_skips_failed_symbols(monkeypatch):
+    fetcher = _fetcher()
+
+    def fake_get(commodity: str) -> pl.DataFrame:
+        if commodity == "brent":
+            raise DataFetchError("boom")
+        ticker = fetcher.ENERGY_SYMBOLS[commodity]["ticker"]
+        return pl.DataFrame(
+            {
+                "Datetime": [pd.Timestamp("2024-01-02 14:30").to_pydatetime()],
+                "Symbol": [ticker],
+                "Open": [1.0],
+                "High": [1.0],
+                "Low": [1.0],
+                "Close": [1.0],
+                "Volume": [1],
+            }
+        )
+
+    monkeypatch.setattr(fetcher, "get_commodity_data", fake_get)
+    out = fetcher.fetch_all_commodities()
+    assert not out.is_empty()
+    assert "BZ=F" not in out["Symbol"].to_list()
+    assert "CL=F" in out["Symbol"].to_list()
+
+
+def test_logs_warning_on_empty_result(monkeypatch, caplog):
+    monkeypatch.setattr(df_mod.yf, "download", lambda *_a, **_k: pd.DataFrame())
+    with caplog.at_level(logging.WARNING, logger="energex.data_fetcher"):
+        _fetcher().get_commodity_data("crude")
+    assert any("No data" in r.message for r in caplog.records)


### PR DESCRIPTION
**Phase 2 of the remediation roadmap (ASSESSMENT.md §4).** Wires the 'production' controls that were defined but dead, and makes ingestion observable and resilient.

- **data_fetcher**: config-driven `timeout` + exponential-backoff **retry**; raise `DataFetchError` on a real failure and return empty **only** for a genuinely empty result (an outage was previously indistinguishable from a weekend); `fetch_all` logs+skips a failed symbol instead of aborting; `print()` → module logger.
- **main**: `setup_logging()` wired at entry from `LoggingConfig`; `print()` → logger.
- **database**: `print()` → logger.
- **config**: `DataFetchConfig` gets `env_prefix='DATAFETCH_'` (it was binding bare env vars).
- Removes the temporary **T201** print-ignores — the package no longer uses `print()`.

### Tests (TDD)
retries exhausted → `DataFetchError`; empty result → empty frame (no raise); retry-then-succeed; `fetch_all` skips a failing symbol; warning logged on empty. Full suite **64 green**; ruff clean (no print ignores left).

Note: LLM rate-limiting + TTL cache (the rest of R10) land with the sentiment PR (R6), since they touch the same pipeline.