### PR TITLE
fix(sentiment): point-in-time join, tz-aware news, no fan-out, robust fallback (R6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ warn_unused_configs = true
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = ["yfinance.*", "plotly.*", "duckdb.*", "feedparser.*", "bs4.*", "pytz"]
+module = ["yfinance.*", "plotly.*", "duckdb.*", "feedparser.*", "bs4.*", "pytz", "requests"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/energex/analysis/market_sentiment.py
+++ b/src/energex/analysis/market_sentiment.py
@@ -227,9 +227,10 @@ Only output valid JSON, nothing else."""
                 self._sentiment_cache[cache_key] = result
                 return result
 
-            except (json.JSONDecodeError, LLMProviderError) as e:
+            except (json.JSONDecodeError, LLMProviderError, TypeError, ValueError, KeyError) as e:
+                # A malformed field (e.g. a quoted number) must not abort the whole
+                # batch — degrade to the rule-based fallback for this one article.
                 self.logger.warning(f"LLM analysis failed for '{title}': {e}")
-                # Fall through to rule-based fallback
 
         # Fallback: simple rule-based sentiment
         result = self._rule_based_sentiment(title, summary)
@@ -303,6 +304,18 @@ Only output valid JSON, nothing else."""
             "key_factors": ["Rule-based analysis"],
         }
 
+    @staticmethod
+    def _coerce_utc(df: pl.DataFrame) -> pl.DataFrame:
+        """Make the Datetime column tz-aware UTC so price/news joins never mix tzs."""
+        if "Datetime" not in df.columns:
+            return df
+        dtype = df.schema["Datetime"]
+        if isinstance(dtype, pl.Datetime):
+            if dtype.time_zone is None:
+                return df.with_columns(pl.col("Datetime").dt.replace_time_zone("UTC"))
+            return df.with_columns(pl.col("Datetime").dt.convert_time_zone("UTC"))
+        return df
+
     def add_sentiment_to_prices(
         self,
         sentiment_df: pl.DataFrame,
@@ -337,13 +350,23 @@ Only output valid JSON, nothing else."""
                 ]
             )
 
-        # Aggregate sentiment by Symbol and time window
+        # Align timezones: price and news timestamps must share one tz for join_asof.
+        price_df = self._coerce_utc(self.df)
+        sentiment_df = self._coerce_utc(sentiment_df)
+
+        # Label each window at its END so a backward asof-join can only attach a
+        # window's sentiment to bars at/after the window closes — news published
+        # mid-window never leaks onto an earlier bar (look-ahead bias).
+        windowed = sentiment_df.with_columns(
+            pl.col("Datetime")
+            .dt.truncate(time_window)
+            .dt.offset_by(time_window)
+            .alias("time_window")
+        )
+
         if aggregation == "mean":
             agg_sentiment = (
-                sentiment_df.with_columns(
-                    [pl.col("Datetime").dt.truncate(time_window).alias("time_window")]
-                )
-                .group_by(["Symbol", "time_window"])
+                windowed.group_by(["Symbol", "time_window"])
                 .agg(
                     [
                         pl.col("sentiment_score").mean().alias("avg_sentiment"),
@@ -354,17 +377,17 @@ Only output valid JSON, nothing else."""
                 .rename({"time_window": "Datetime"})
             )
         elif aggregation == "weighted":
-            # Weighted average: (sentiment * confidence).sum() / confidence.sum()
+            # Confidence-weighted average, guarded against a zero-confidence window.
             agg_sentiment = (
-                sentiment_df.with_columns(
-                    [pl.col("Datetime").dt.truncate(time_window).alias("time_window")]
-                )
-                .group_by(["Symbol", "time_window"])
+                windowed.group_by(["Symbol", "time_window"])
                 .agg(
                     [
-                        (pl.col("sentiment_score") * pl.col("confidence"))
-                        .sum()
-                        .truediv(pl.col("confidence").sum())
+                        pl.when(pl.col("confidence").sum() != 0)
+                        .then(
+                            (pl.col("sentiment_score") * pl.col("confidence")).sum()
+                            / pl.col("confidence").sum()
+                        )
+                        .otherwise(pl.col("sentiment_score").mean())
                         .alias("avg_sentiment"),
                         pl.col("confidence").mean().alias("avg_confidence"),
                         pl.col("news_title").count().alias("news_count"),
@@ -374,8 +397,7 @@ Only output valid JSON, nothing else."""
             )
         else:  # latest
             agg_sentiment = (
-                sentiment_df.sort("Datetime", descending=True)
-                .with_columns([pl.col("Datetime").dt.truncate(time_window).alias("time_window")])
+                windowed.sort("Datetime", descending=True)
                 .group_by(["Symbol", "time_window"])
                 .agg(
                     [
@@ -387,9 +409,9 @@ Only output valid JSON, nothing else."""
                 .rename({"time_window": "Datetime"})
             )
 
-        # Join with price data using asof join (backward fill)
+        # Join with price data using a backward asof-join.
         result = (
-            self.df.sort(["Symbol", "Datetime"])
+            price_df.sort(["Symbol", "Datetime"])
             .join_asof(
                 agg_sentiment.sort(["Symbol", "Datetime"]),
                 on="Datetime",

--- a/src/energex/news_fetcher.py
+++ b/src/energex/news_fetcher.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from energex.exceptions import DataFetchError
 
@@ -88,7 +88,7 @@ class RSSNewsSource(NewsSource):
             ) from e
 
         articles: list[NewsArticle] = []
-        cutoff_time = datetime.now() - timedelta(hours=hours_back)
+        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=hours_back)
 
         for feed_url in self.ENERGY_RSS_FEEDS:
             try:
@@ -98,13 +98,16 @@ class RSSNewsSource(NewsSource):
                 for entry in feed.entries:
                     # Parse publication date
                     pub_date = None
+                    # feedparser normalizes *_parsed to UTC; make it tz-aware so all
+                    # article timestamps share one timezone (mixing naive/aware crashes
+                    # the downstream sort and the price join_asof).
                     if hasattr(entry, "published_parsed") and entry.published_parsed:
-                        pub_date = datetime(*entry.published_parsed[:6])
+                        pub_date = datetime(*entry.published_parsed[:6], tzinfo=timezone.utc)
                     elif hasattr(entry, "updated_parsed") and entry.updated_parsed:
-                        pub_date = datetime(*entry.updated_parsed[:6])
+                        pub_date = datetime(*entry.updated_parsed[:6], tzinfo=timezone.utc)
                     else:
                         # If no date, assume recent
-                        pub_date = datetime.now()
+                        pub_date = datetime.now(timezone.utc)
 
                     # Filter by time window
                     if pub_date < cutoff_time:
@@ -122,16 +125,17 @@ class RSSNewsSource(NewsSource):
                         entry.title + " " + (summary or ""), symbols
                     )
 
-                    if relevant_symbols:
-                        article = NewsArticle(
-                            title=entry.title,
-                            source=feed_url.split("/")[2],  # Extract domain
-                            published_at=pub_date,
-                            url=entry.link,
-                            summary=summary,
-                            symbols=relevant_symbols,
-                        )
-                        articles.append(article)
+                    # Keep general (no-keyword-match) articles too, but with
+                    # symbols=None so the analyzer assigns them by impact sector.
+                    article = NewsArticle(
+                        title=entry.title,
+                        source=feed_url.split("/")[2],  # Extract domain
+                        published_at=pub_date,
+                        url=entry.link,
+                        summary=summary,
+                        symbols=relevant_symbols or None,
+                    )
+                    articles.append(article)
 
             except Exception as e:
                 self.logger.warning(f"Failed to fetch RSS feed {feed_url}: {e}")
@@ -166,10 +170,9 @@ class RSSNewsSource(NewsSource):
             if any(keyword in text_lower for keyword in keywords):
                 matched.append(symbol)
 
-        # If no specific match, assign to all symbols (general energy news)
-        if not matched:
-            matched = symbols
-
+        # No blanket fallback: a generic headline returns [] here so the analyzer can
+        # assign it by LLM impact_sector instead of triple-counting it across all
+        # symbols with identical sentiment.
         return matched
 
 
@@ -228,7 +231,7 @@ class NewsAPISource(NewsSource):
                         published_at=pub_date,
                         url=item["url"],
                         summary=item.get("description"),
-                        symbols=symbols,  # Assign all symbols for now
+                        symbols=None,  # assigned by the analyzer's impact-sector mapping
                     )
                     articles.append(article)
 

--- a/tests/test_news_fetcher.py
+++ b/tests/test_news_fetcher.py
@@ -1,0 +1,21 @@
+"""Tests for news symbol matching — no blanket fan-out across all symbols (R6)."""
+
+from energex.news_fetcher import RSSNewsSource
+
+SYMBOLS = ["CL=F", "BZ=F", "NG=F"]
+
+
+def test_match_symbols_returns_empty_for_generic_text():
+    # Previously returned ALL symbols (triple-counting generic news).
+    assert RSSNewsSource()._match_symbols("the economy grew last quarter", SYMBOLS) == []
+
+
+def test_match_symbols_matches_specific_keyword():
+    assert RSSNewsSource()._match_symbols("brent crude rallies on supply fears", SYMBOLS) == [
+        "BZ=F"
+    ]
+
+
+def test_match_symbols_can_match_multiple():
+    matched = RSSNewsSource()._match_symbols("oil price and natural gas both climb", SYMBOLS)
+    assert set(matched) == {"CL=F", "NG=F"}

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -1,0 +1,124 @@
+"""Tests for sentiment correctness: look-ahead, timezones, fan-out, fallback (R6)."""
+
+from datetime import datetime, timezone
+
+import polars as pl
+import pytest
+
+from energex.analysis.market_sentiment import MarketSentimentAnalyzer
+from energex.news_fetcher import NewsArticle
+
+
+def _prices(symbols, times):
+    rows = []
+    for sym in symbols:
+        for t in times:
+            rows.append(
+                {
+                    "Datetime": t,
+                    "Symbol": sym,
+                    "Open": 1.0,
+                    "High": 1.0,
+                    "Low": 1.0,
+                    "Close": 1.0,
+                    "Volume": 1,
+                }
+            )
+    return pl.DataFrame(rows)
+
+
+def _sentiment_row(dt, symbol="CL=F", score=0.8):
+    return pl.DataFrame(
+        {
+            "Datetime": [dt],
+            "Symbol": [symbol],
+            "news_title": ["headline"],
+            "news_url": ["https://x/1"],
+            "sentiment_score": [score],
+            "confidence": [0.9],
+            "impact_sector": ["Oil"],
+            "trade_signal": ["LONG"],
+            "key_factors": ["[]"],
+        }
+    )
+
+
+def test_future_news_does_not_leak_onto_earlier_bar():
+    t1015 = datetime(2024, 1, 2, 10, 15, tzinfo=timezone.utc)
+    t1100 = datetime(2024, 1, 2, 11, 0, tzinfo=timezone.utc)
+    prices = _prices(["CL=F"], [t1015, t1100])
+    analyzer = MarketSentimentAnalyzer(prices)
+
+    # News published 10:45 (inside the 10:00-11:00 window).
+    sentiment = _sentiment_row(datetime(2024, 1, 2, 10, 45, tzinfo=timezone.utc))
+    out = analyzer.add_sentiment_to_prices(sentiment, time_window="1h").sort("Datetime")
+
+    at_1015 = out.filter(pl.col("Datetime") == t1015)["avg_sentiment"][0]
+    at_1100 = out.filter(pl.col("Datetime") == t1100)["avg_sentiment"][0]
+    assert at_1015 == 0.0  # earlier bar must not see the later news
+    assert at_1100 == pytest.approx(0.8)
+
+
+def test_join_handles_naive_price_and_aware_sentiment():
+    # Price bars naive, news tz-aware — previously crashed with a SchemaError.
+    prices = _prices(["CL=F"], [datetime(2024, 1, 2, 12, 0)])  # naive
+    analyzer = MarketSentimentAnalyzer(prices)
+    sentiment = _sentiment_row(datetime(2024, 1, 2, 9, 0, tzinfo=timezone.utc))
+    out = analyzer.add_sentiment_to_prices(sentiment)
+    assert "avg_sentiment" in out.columns
+    assert out.height == 1
+
+
+def test_specific_oil_headline_maps_to_single_symbol(monkeypatch):
+    prices = _prices(["CL=F", "BZ=F", "NG=F"], [datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc)])
+    analyzer = MarketSentimentAnalyzer(prices)
+    analyzer.llm = None  # force rule-based path
+
+    articles = [
+        NewsArticle(
+            title="Oil prices surge on OPEC production cuts",
+            source="src",
+            published_at=datetime(2024, 1, 2, 11, 0, tzinfo=timezone.utc),
+            url="https://x/1",
+            summary=None,
+            symbols=None,  # general feed item -> assigned by impact sector
+        )
+    ]
+    monkeypatch.setattr(analyzer.news_fetcher, "fetch_all", lambda *a, **k: articles)
+
+    sdf = analyzer.analyze_news_sentiment(symbols=["CL=F", "BZ=F", "NG=F"])
+    # 'Oil' sector maps to CL=F only — not triple-counted across all three.
+    assert set(sdf["Symbol"].unique()) == {"CL=F"}
+
+
+def test_non_json_llm_response_falls_back_to_rule_based():
+    prices = _prices(["CL=F"], [datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc)])
+    analyzer = MarketSentimentAnalyzer(prices)
+
+    class BadLLM:
+        def is_available(self):
+            return True
+
+        def generate_completion(self, system, user):
+            return "this is not json"
+
+    analyzer.llm = BadLLM()  # type: ignore[assignment]
+    result = analyzer._analyze_article("Oil rises sharply", "summary")
+    assert result["key_factors"] == ["Rule-based analysis"]
+
+
+def test_malformed_numeric_field_does_not_abort():
+    prices = _prices(["CL=F"], [datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc)])
+    analyzer = MarketSentimentAnalyzer(prices)
+
+    class TypeErrorLLM:
+        def is_available(self):
+            return True
+
+        def generate_completion(self, system, user):
+            # sentiment_score is an object -> min()/max() raise TypeError
+            return '{"sentiment_score": {"bad": 1}, "confidence": 0.5}'
+
+    analyzer.llm = TypeErrorLLM()  # type: ignore[assignment]
+    result = analyzer._analyze_article("Gas falls", "summary")
+    assert result["key_factors"] == ["Rule-based analysis"]


### PR DESCRIPTION
**Phase 2 of the remediation roadmap (ASSESSMENT.md §4).** First-order correctness bugs for a trading signal.

- **Look-ahead leak**: `add_sentiment_to_prices` floored each article to its window START, so a 10:45 headline attached to a 10:15 bar. Now each window is labeled at its **END** before the backward asof-join — mid-window news can only reach bars at/after the window closes.
- **Timezone crash**: news timestamps are now tz-aware UTC (feedparser `*_parsed` is UTC; `datetime.now(timezone.utc)` cutoffs), and the join coerces both price + news Datetime to UTC — fixes the `SchemaError` whenever sentiment came from NewsAPI.
- **3× fan-out**: `_match_symbols` no longer blanket-assigns all symbols, and NewsAPI no longer sets `symbols=all`; generic items carry `symbols=None` and are assigned by LLM **impact sector** (the previously-dead mapping), so a generic headline isn't triple-counted.
- **Robust fallback**: broaden the LLM `except` to `TypeError/ValueError/KeyError` so one malformed field degrades to rule-based instead of aborting the batch; guard the confidence-weighted average against a zero-confidence window.

### Tests (TDD; retro-verified RED by stashing the fixes)
Future news never lands on an earlier bar; naive-price/aware-news join no longer crashes; generic text matches **no** symbols (specific keywords still match); a malformed numeric LLM field falls back to rule-based. Full suite **72 green**; ruff clean.

Note: structured-outputs (R6b), rate-limiting, and TTL cache land with the sentiment-hardening PR (R13).