### PR TITLE
feat(storage): context manager, query helper, configurable db_path (R15)

### DIFF
--- a/src/energex/database.py
+++ b/src/energex/database.py
@@ -1,10 +1,13 @@
 # src/energex/database.py
 import logging
 from pathlib import Path
+from types import TracebackType
+from typing import Any
 
 import duckdb
 import polars as pl
 
+from energex.config import get_settings
 from energex.exceptions import DatabaseError
 
 logger = logging.getLogger(__name__)
@@ -21,9 +24,13 @@ class EnergyDatabase:
     #: Canonical column order for the ``intraday_prices`` table.
     COLUMNS = ("Datetime", "Symbol", "Open", "High", "Low", "Close", "Volume")
 
-    def __init__(self, db_path: str = "energy.db", read_only: bool = False):
+    def __init__(self, db_path: str | None = None, read_only: bool = False):
+        # Resolve the path from configuration (ENERGEX_DB_PATH) when not given.
+        if db_path is None:
+            db_path = str(get_settings().database.db_path)
         self.db_path = Path(db_path)
         self.read_only = read_only
+        self._closed = False
         if read_only and not self.db_path.exists():
             raise DatabaseError(
                 f"Cannot open database read-only; file does not exist: {self.db_path}"
@@ -133,3 +140,26 @@ class EnergyDatabase:
             self.conn.execute("ROLLBACK")
             logger.error("Error inserting data: %s", e)
             raise
+
+    def query(self, sql: str, params: list[Any] | None = None) -> pl.DataFrame:
+        """Run a read query on a separate cursor and return a Polars DataFrame."""
+        result = pl.from_arrow(self.conn.cursor().execute(sql, params or []).arrow())
+        assert isinstance(result, pl.DataFrame)
+        return result
+
+    def close(self) -> None:
+        """Close the underlying DuckDB connection (idempotent)."""
+        if not self._closed:
+            self.conn.close()
+            self._closed = True
+
+    def __enter__(self) -> "EnergyDatabase":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/tests/test_database_ergonomics.py
+++ b/tests/test_database_ergonomics.py
@@ -1,0 +1,41 @@
+"""Tests for EnergyDatabase ergonomics: context manager, query helper, db_path (R15)."""
+
+import polars as pl
+import pytest
+
+from energex.config import reset_settings
+from energex.database import EnergyDatabase
+
+
+def test_context_manager_closes_connection(sample_ohlcv, tmp_db_path):
+    with EnergyDatabase(tmp_db_path) as db:
+        db.insert_intraday_data(sample_ohlcv)
+    # After the block the connection is closed.
+    with pytest.raises(Exception):  # noqa: B017 - duckdb raises on a closed connection
+        db.conn.execute("SELECT 1")
+
+
+def test_close_is_idempotent(tmp_db_path):
+    db = EnergyDatabase(tmp_db_path)
+    db.close()
+    db.close()  # must not raise
+
+
+def test_query_returns_dataframe(sample_ohlcv, tmp_db_path):
+    with EnergyDatabase(tmp_db_path) as db:
+        db.insert_intraday_data(sample_ohlcv)
+        out = db.query("SELECT * FROM intraday_prices WHERE Symbol = ? ORDER BY Datetime", ["CL=F"])
+    assert isinstance(out, pl.DataFrame)
+    assert set(out["Symbol"].unique()) == {"CL=F"}
+
+
+def test_db_path_none_resolves_from_settings(monkeypatch, tmp_path):
+    target = tmp_path / "configured.db"
+    monkeypatch.setenv("ENERGEX_DB_PATH", str(target))
+    reset_settings()
+    try:
+        db = EnergyDatabase()  # None -> settings.database.db_path
+        assert str(db.db_path) == str(target)
+        db.close()
+    finally:
+        reset_settings()


### PR DESCRIPTION
**Phase 4 polish (ASSESSMENT.md R15).**

- `EnergyDatabase` is a **context manager** (`with EnergyDatabase(...) as db`) with an idempotent `close()`.
- New `query(sql, params)` read helper returns a Polars DataFrame (separate cursor).
- `db_path` defaults to `None` → resolved from `settings.database.db_path` (`ENERGEX_DB_PATH`), so the writer location is configurable.
- The redundant secondary index was already removed in R1+R2 (the PK indexes `(Symbol, Datetime)`).

Tests (TDD): context manager closes the connection; `close()` idempotent; `query()` filters; `db_path=None` resolves from env. Full suite **84 green**; ruff clean.