### PR TITLE
feat(volatility): correct realized-variance methodology + Yang-Zhang (R7)

### DIFF
--- a/src/energex/analysis/volatility.py
+++ b/src/energex/analysis/volatility.py
@@ -78,3 +78,89 @@ class VolatilityAnalyzer:
                 ),
             ]
         )
+
+    # ------------------------------------------------------------------
+    # Methodologically-correct estimators (ASSESSMENT R7)
+    # ------------------------------------------------------------------
+    def realized_volatility_daily(self) -> pl.DataFrame:
+        """Canonical daily realized volatility per symbol.
+
+        Realized variance is the SUM of squared intraday log returns (not a
+        mean-subtracted rolling std), with the overnight (cross-day) return masked so
+        a session gap is never treated as an intraday return. Daily volatility
+        (sqrt of the daily realized variance) is annualized by sqrt(252).
+        """
+        df = self.df.sort(["Symbol", "Datetime"]).with_columns(
+            [
+                pl.col("Close").log().diff().over("Symbol").alias("log_ret"),
+                pl.col("Datetime").dt.date().alias("date"),
+            ]
+        )
+        # Mask the first bar of each day (its diff spans the overnight gap).
+        df = df.with_columns(
+            pl.when(pl.col("date") != pl.col("date").shift(1).over("Symbol"))
+            .then(None)
+            .otherwise(pl.col("log_ret"))
+            .alias("log_ret")
+        )
+        return (
+            df.group_by(["Symbol", "date"])
+            .agg(pl.col("log_ret").pow(2).sum().alias("realized_variance"))
+            .with_columns(
+                (pl.col("realized_variance").sqrt() * np.sqrt(252)).alias("realized_vol_annual")
+            )
+            .sort(["Symbol", "date"])
+        )
+
+    def to_daily_ohlc(self) -> pl.DataFrame:
+        """Resample intraday bars to daily OHLC per symbol."""
+        return (
+            self.df.sort(["Symbol", "Datetime"])
+            .group_by_dynamic("Datetime", every="1d", group_by="Symbol")
+            .agg(
+                [
+                    pl.col("Open").first().alias("Open"),
+                    pl.col("High").max().alias("High"),
+                    pl.col("Low").min().alias("Low"),
+                    pl.col("Close").last().alias("Close"),
+                    pl.col("Volume").sum().alias("Volume"),
+                ]
+            )
+            .sort(["Symbol", "Datetime"])
+        )
+
+    def yang_zhang_volatility(self) -> pl.DataFrame:
+        """Annualized Yang-Zhang volatility per symbol (drift- and gap-independent).
+
+        Computed on DAILY OHLC bars (range estimators are daily tools). Combines
+        overnight, open-to-close, and Rogers-Satchell variances; requires >= 2 days.
+        """
+        daily = self.to_daily_ohlc().with_columns(
+            pl.col("Close").shift(1).over("Symbol").alias("prev_close")
+        )
+        daily = daily.with_columns(
+            [
+                (pl.col("Open") / pl.col("prev_close")).log().alias("o"),
+                (pl.col("Close") / pl.col("Open")).log().alias("c"),
+                (
+                    (pl.col("High") / pl.col("Close")).log()
+                    * (pl.col("High") / pl.col("Open")).log()
+                    + (pl.col("Low") / pl.col("Close")).log()
+                    * (pl.col("Low") / pl.col("Open")).log()
+                ).alias("rs"),
+            ]
+        )
+        agg = daily.group_by("Symbol").agg(
+            [
+                pl.col("o").var().alias("v_o"),
+                pl.col("c").var().alias("v_c"),
+                pl.col("rs").mean().alias("v_rs"),
+                pl.len().alias("n"),
+            ]
+        )
+        k = 0.34 / (1.34 + (pl.col("n") + 1) / (pl.col("n") - 1))
+        return agg.with_columns(
+            (
+                (pl.col("v_o") + k * pl.col("v_c") + (1 - k) * pl.col("v_rs")).sqrt() * np.sqrt(252)
+            ).alias("yang_zhang_vol_annual")
+        ).select(["Symbol", "n", "yang_zhang_vol_annual"])

--- a/tests/test_volatility_methodology.py
+++ b/tests/test_volatility_methodology.py
@@ -1,0 +1,69 @@
+"""Tests for the corrected volatility estimators (R7)."""
+
+import math
+from datetime import datetime, timedelta, timezone
+
+import polars as pl
+import pytest
+
+from energex.analysis.volatility import VolatilityAnalyzer
+
+UTC = timezone.utc
+
+
+def _intraday(symbol: str, day: datetime, closes: list[float]) -> list[dict]:
+    base = datetime(day.year, day.month, day.day, 14, 30, tzinfo=UTC)
+    return [
+        {
+            "Datetime": base + timedelta(minutes=i),
+            "Symbol": symbol,
+            "Open": c,
+            "High": c + 0.5,
+            "Low": c - 0.5,
+            "Close": c,
+            "Volume": 100,
+        }
+        for i, c in enumerate(closes)
+    ]
+
+
+def test_realized_variance_is_sum_of_squared_intraday_returns():
+    closes = [100.0, 101.0, 100.0, 102.0]
+    df = pl.DataFrame(_intraday("CL=F", datetime(2024, 1, 2), closes))
+    out = VolatilityAnalyzer(df).realized_volatility_daily()
+    rets = [math.log(101 / 100), math.log(100 / 101), math.log(102 / 100)]
+    expected = sum(r * r for r in rets)
+    assert out["realized_variance"][0] == pytest.approx(expected)
+    assert out["realized_vol_annual"][0] == pytest.approx(math.sqrt(expected) * math.sqrt(252))
+
+
+def test_overnight_return_is_masked():
+    rows = _intraday("CL=F", datetime(2024, 1, 2), [100.0, 101.0])
+    rows += _intraday("CL=F", datetime(2024, 1, 3), [200.0, 202.0])  # big overnight jump
+    out = VolatilityAnalyzer(pl.DataFrame(rows)).realized_volatility_daily()
+    day2 = out.filter(pl.col("date") == datetime(2024, 1, 3).date())
+    # Only the intraday ln(202/200) counts — not the overnight ln(200/101).
+    assert day2["realized_variance"][0] == pytest.approx(math.log(202 / 200) ** 2)
+
+
+def test_to_daily_ohlc_aggregates_correctly():
+    df = pl.DataFrame(_intraday("CL=F", datetime(2024, 1, 2), [100.0, 105.0, 95.0, 102.0]))
+    daily = VolatilityAnalyzer(df).to_daily_ohlc()
+    assert daily.height == 1
+    row = daily.row(0, named=True)
+    assert row["Open"] == 100.0
+    assert row["High"] == 105.5
+    assert row["Low"] == 94.5
+    assert row["Close"] == 102.0
+    assert row["Volume"] == 400
+
+
+def test_yang_zhang_runs_and_is_positive():
+    rows: list[dict] = []
+    for d in range(2, 8):  # 6 trading days
+        rows += _intraday("CL=F", datetime(2024, 1, d), [100.0 + d, 101.0 + d, 100.5 + d])
+    out = VolatilityAnalyzer(pl.DataFrame(rows)).yang_zhang_volatility()
+    assert out.height == 1
+    yz = out["yang_zhang_vol_annual"][0]
+    assert yz is not None and yz > 0 and math.isfinite(yz)
+    assert out["n"][0] == 6


### PR DESCRIPTION
**Phase 3 (ASSESSMENT.md R7).** R3 made the estimators *run*; this makes the math *correct*, as new methods (the rolling ones stay for continuity).

- **`realized_volatility_daily()`** — canonical realized variance = **sum of squared intraday log returns** (not a mean-subtracted `rolling_std`), with the **overnight/cross-day return masked** so a session gap is never treated as an intraday return; daily vol annualized by `sqrt(252)` (not the naive `sqrt(252*1440)`).
- **`to_daily_ohlc()`** — resample 1-min → daily OHLC (range estimators are daily tools).
- **`yang_zhang_volatility()`** — drift- and gap-independent daily estimator (overnight + open-to-close + Rogers-Satchell), annualized.

Tests (deterministic): RV equals the hand-computed Σr²; the overnight jump is excluded; daily resample aggregates O/H/L/C/V; Yang-Zhang is positive/finite over 6 days. Full suite **88 green**; ruff clean.

Sources: Liu-Patton-Sheppard 2015 (5-min RV), Yang-Zhang 2000. Sub-5-min noise-robust estimators (two-scale RV, realized kernel) remain documented future work (R18).