### PR TITLE
feat(sources): pluggable DataSource abstraction + vendor stubs (R14)

### DIFF
--- a/src/energex/service/pipeline.py
+++ b/src/energex/service/pipeline.py
@@ -1,25 +1,27 @@
-"""Ingestion pipeline: fetch -> idempotent upsert -> checkpoint."""
+"""Ingestion pipeline: fetch (via a pluggable DataSource) -> upsert -> checkpoint."""
 
 import logging
+import os
 
-from energex.data_fetcher import EnergyDataFetcher
 from energex.database import EnergyDatabase
+from energex.sources import get_data_source
 
 logger = logging.getLogger(__name__)
 
 
-def run_ingestion(db: EnergyDatabase) -> int:
+def run_ingestion(db: EnergyDatabase, source_name: str | None = None) -> int:
     """Fetch all commodities and upsert into the store.
 
-    Returns the number of rows upserted. Safe to run repeatedly: the upsert merges
-    overlapping windows, so a missed or duplicated run is idempotent.
+    The data source defaults to ENERGEX_DATA_SOURCE (or 'yfinance'). Safe to run
+    repeatedly: the upsert merges overlapping windows, so a missed or duplicated run
+    is idempotent.
     """
-    fetcher = EnergyDataFetcher()
-    df = fetcher.fetch_all_commodities()
+    source = get_data_source(source_name or os.environ.get("ENERGEX_DATA_SOURCE", "yfinance"))
+    df = source.fetch_all()
     if df.is_empty():
-        logger.info("Ingestion produced no rows")
+        logger.info("Ingestion produced no rows (source=%s)", source.name)
         return 0
     db.insert_intraday_data(df)
     db.conn.execute("CHECKPOINT")
-    logger.info("Ingestion upserted %d rows", df.height)
+    logger.info("Ingestion upserted %d rows (source=%s)", df.height, source.name)
     return df.height

--- a/src/energex/sources/__init__.py
+++ b/src/energex/sources/__init__.py
@@ -1,0 +1,45 @@
+"""Pluggable market-data sources.
+
+>>> from energex.sources import get_data_source
+>>> source = get_data_source("yfinance")  # default
+>>> df = source.fetch_all()
+"""
+
+from energex.exceptions import ConfigurationError
+from energex.sources.base import DataSource
+from energex.sources.stubs import (
+    DatabentoDataSource,
+    EIASpotDataSource,
+    ICEBrentDataSource,
+)
+from energex.sources.yfinance_source import YFinanceDataSource
+
+_SOURCES: dict[str, type[DataSource]] = {
+    "yfinance": YFinanceDataSource,
+    "databento": DatabentoDataSource,
+    "ice-brent": ICEBrentDataSource,
+    "eia-spot": EIASpotDataSource,
+}
+
+
+def get_data_source(name: str = "yfinance") -> DataSource:
+    """Construct a data source by name (default: yfinance)."""
+    key = name.lower()
+    if key not in _SOURCES:
+        raise ConfigurationError(f"Unknown data source: {name}. Available: {sorted(_SOURCES)}")
+    return _SOURCES[key]()
+
+
+def list_data_sources() -> list[str]:
+    return sorted(_SOURCES)
+
+
+__all__ = [
+    "DataSource",
+    "YFinanceDataSource",
+    "DatabentoDataSource",
+    "ICEBrentDataSource",
+    "EIASpotDataSource",
+    "get_data_source",
+    "list_data_sources",
+]

--- a/src/energex/sources/base.py
+++ b/src/energex/sources/base.py
@@ -1,0 +1,27 @@
+"""Abstract market-data source.
+
+A DataSource returns standardized OHLCV frames (UTC instants, the canonical column
+set) so the rest of energex is decoupled from any single vendor. yfinance becomes one
+opt-in adapter among licensed alternatives (ASSESSMENT R14).
+"""
+
+from abc import ABC, abstractmethod
+
+import polars as pl
+
+
+class DataSource(ABC):
+    """Base class for market-data sources."""
+
+    #: Short identifier (e.g. "yfinance", "databento").
+    name: str = "abstract"
+    #: Whether the vendor's terms permit redistribution/commercial use.
+    redistributable: bool = False
+
+    @abstractmethod
+    def fetch(self, commodity: str) -> pl.DataFrame:
+        """Fetch one commodity key (e.g. 'crude', 'brent', 'gas')."""
+
+    @abstractmethod
+    def fetch_all(self) -> pl.DataFrame:
+        """Fetch and combine all supported commodities."""

--- a/src/energex/sources/stubs.py
+++ b/src/energex/sources/stubs.py
@@ -1,0 +1,52 @@
+"""Documented stubs for licensed/production data sources (ASSESSMENT R14).
+
+These define the adapter boundary and fail clearly with setup guidance. Wiring the live
+calls requires vendor accounts / API keys and is intentionally deferred.
+"""
+
+import polars as pl
+
+from energex.sources.base import DataSource
+
+
+class _NotConfiguredSource(DataSource):
+    redistributable = True
+    setup: str = "not configured"
+
+    def fetch(self, commodity: str) -> pl.DataFrame:
+        raise NotImplementedError(self.setup)
+
+    def fetch_all(self) -> pl.DataFrame:
+        raise NotImplementedError(self.setup)
+
+
+class DatabentoDataSource(_NotConfiguredSource):
+    """Primary intraday source for CME CL/NG (per-contract symbology + expiry + OI)."""
+
+    name = "databento"
+    setup = (
+        "Databento GLBX.MDP3 adapter not implemented. It provides per-contract CME "
+        "intraday (CL/NG) with expiry and open interest. Needs DATABENTO_API_KEY. "
+        "See ASSESSMENT.md R14."
+    )
+
+
+class ICEBrentDataSource(_NotConfiguredSource):
+    """Brent (BZ) is an ICE product, not on CME Globex — needs an ICE-licensed vendor."""
+
+    name = "ice-brent"
+    setup = (
+        "ICE Brent adapter not implemented. Brent is an ICE product; use an "
+        "ICE-licensed vendor (Refinitiv / ICE Data Services / Barchart). See ASSESSMENT.md R14."
+    )
+
+
+class EIASpotDataSource(_NotConfiguredSource):
+    """Free EIA/FRED spot benchmarks (WTI Cushing, Henry Hub) for the basis/carry leg."""
+
+    name = "eia-spot"
+    setup = (
+        "EIA/FRED spot adapter not implemented. It supplies the cash/spot leg "
+        "(WTI Cushing, Henry Hub) for real basis/implied-carry. Needs a free EIA_API_KEY. "
+        "See ASSESSMENT.md R14 / R8."
+    )

--- a/src/energex/sources/yfinance_source.py
+++ b/src/energex/sources/yfinance_source.py
@@ -1,0 +1,25 @@
+"""yfinance data source — PERSONAL RESEARCH ONLY.
+
+Yahoo's terms prohibit automated/commercial use; 1-minute history is capped at ~7 days
+per request; CL=F/BZ=F/NG=F are continuous front-month *proxies*, not dated contracts.
+Use a licensed source (see energex.sources.stubs) for production / curve analytics.
+"""
+
+import polars as pl
+
+from energex.data_fetcher import EnergyDataFetcher
+from energex.sources.base import DataSource
+
+
+class YFinanceDataSource(DataSource):
+    name = "yfinance"
+    redistributable = False
+
+    def __init__(self) -> None:
+        self._fetcher = EnergyDataFetcher()
+
+    def fetch(self, commodity: str) -> pl.DataFrame:
+        return self._fetcher.get_commodity_data(commodity)
+
+    def fetch_all(self) -> pl.DataFrame:
+        return self._fetcher.fetch_all_commodities()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -98,6 +98,7 @@ def test_scheduler_registers_ingest_job():
 
 def test_run_ingestion_upserts(monkeypatch, tmp_db_path):
     from energex.service import pipeline
+    from energex.sources.yfinance_source import YFinanceDataSource
 
     fake = pl.DataFrame(
         {
@@ -110,7 +111,7 @@ def test_run_ingestion_upserts(monkeypatch, tmp_db_path):
             "Volume": [1],
         }
     )
-    monkeypatch.setattr(pipeline.EnergyDataFetcher, "fetch_all_commodities", lambda self: fake)
+    monkeypatch.setattr(YFinanceDataSource, "fetch_all", lambda self: fake)
     db = EnergyDatabase(tmp_db_path)
     n = pipeline.run_ingestion(db)
     count = db.conn.execute("SELECT COUNT(*) FROM intraday_prices").fetchone()[0]

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,42 @@
+"""Tests for the pluggable data-source layer (R14)."""
+
+import polars as pl
+import pytest
+
+from energex import data_fetcher as df_mod
+from energex.exceptions import ConfigurationError
+from energex.sources import get_data_source, list_data_sources
+from energex.sources.yfinance_source import YFinanceDataSource
+
+
+def test_default_source_is_yfinance_and_not_redistributable():
+    src = get_data_source()
+    assert isinstance(src, YFinanceDataSource)
+    assert src.name == "yfinance"
+    assert src.redistributable is False
+
+
+def test_unknown_source_raises():
+    with pytest.raises(ConfigurationError):
+        get_data_source("nope")
+
+
+def test_list_sources():
+    assert set(list_data_sources()) == {"yfinance", "databento", "ice-brent", "eia-spot"}
+
+
+def test_yfinance_source_delegates_to_fetcher(monkeypatch):
+    fake = pl.DataFrame({"Symbol": ["CL=F"]})
+    monkeypatch.setattr(df_mod.EnergyDataFetcher, "fetch_all_commodities", lambda self: fake)
+    out = get_data_source("yfinance").fetch_all()
+    assert out.equals(fake)
+
+
+@pytest.mark.parametrize("name", ["databento", "ice-brent", "eia-spot"])
+def test_stub_sources_raise_not_implemented(name):
+    src = get_data_source(name)
+    assert src.redistributable is True
+    with pytest.raises(NotImplementedError):
+        src.fetch_all()
+    with pytest.raises(NotImplementedError):
+        src.fetch("crude")


### PR DESCRIPTION
**Phase 4 (ASSESSMENT.md R14).** Decouples energex from any single vendor and demotes yfinance to an opt-in adapter.

- **`energex.sources`**: `DataSource` ABC (standardized OHLCV); **`YFinanceDataSource`** labeled *PERSONAL RESEARCH ONLY* (Yahoo ToS, ~7-day 1m cap, continuous front-month proxies); documented **stubs** for **Databento** (CME CL/NG per-contract + expiry/OI), **ICE Brent**, and **EIA/FRED spot** that raise `NotImplementedError` with setup guidance; `get_data_source()` factory + `ENERGEX_DATA_SOURCE`.
- **`pipeline.run_ingestion`** now fetches via the configured `DataSource`.

Per the agreed *abstraction + stubs* scope, live paid-vendor integration is deferred (needs accounts/keys). This is also the honest resolution of **R8**: real term-structure/roll/basis needs the dated-contract + spot data these adapters would supply, so the futures analytics stay gated (R4) until a licensed source is wired.

Tests: default yfinance + non-redistributable; unknown raises; yfinance delegates; stubs raise. Full suite **95 green**; ruff clean.