### PR TITLE
ci: GHCR image build, gitleaks, OIDC publish, wheel packaging (R16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,39 @@ jobs:
         with:
           enable-cache: true
       - run: uv run --all-extras --python ${{ matrix.python-version }} pytest
+
+  secrets:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: gitleaks detect
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.4/gitleaks_8.18.4_linux_x64.tar.gz \
+            | tar -xz gitleaks
+          ./gitleaks detect --no-git --config .gitleaks.toml --redact --verbose
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # On PRs: build only (validates the Dockerfile). On push to main: build + push.
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ghcr.io/oldhero5/energex:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,40 +1,37 @@
 name: Publish to PyPI
 
+# Optional wheel publishing (the primary artifact is the container image built in ci.yml).
+# Uses PyPI Trusted Publishing (OIDC) — no long-lived token. Configure a trusted
+# publisher for this workflow on PyPI before the first release.
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
 
 jobs:
-  build-and-publish:
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.12"
-    
-    - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-    
-    - name: Setup virtual environment and install dependencies
-      run: |
-        uv venv
-        source .venv/bin/activate
-        uv pip install build twine
-    
-    - name: Build package
-      run: |
-        source .venv/bin/activate
-        python -m build
-    
-    - name: Publish to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
-        source .venv/bin/activate
-        twine upload dist/*
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build
+      - run: uvx twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI (OIDC)
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # OIDC trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Test fixtures use obviously-fake placeholder credentials."
+paths = [
+  '''tests/.*''',
+  '''\.env\.example''',
+  '''\.mypy_cache/.*''',
+  '''\.ruff_cache/.*''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
       - id: check-merge-conflict
       - id: check-added-large-files
         args: [--maxkb=2048]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ all = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+# Ship only the package; the sibling src/examples must not leak into the wheel.
+packages = ["src/energex"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"


### PR DESCRIPTION
**Phase 4 (ASSESSMENT.md R16).** Completes the deploy/security pipeline.

- **Wheel packaging**: `[tool.hatch.build.targets.wheel] packages=['src/energex']` so the sibling `src/examples` can't leak into the wheel (verified: the wheel contains only `energex/`).
- **Docker build in CI**: builds on every PR (validates the Dockerfile) and **build+push** `ghcr.io/oldhero5/energex:latest` on push to `main` (gha cache). The image is now the deployable artifact.
- **Secret scan**: `gitleaks` job (`--no-git`, test fixtures allowlisted via `.gitleaks.toml`) + a pre-commit hook.
- **OIDC publishing**: `publish.yml` migrated to **PyPI Trusted Publishing** (no long-lived token), split build/publish, demoted to release/`workflow_dispatch`.

The Docker-build job doubles as the live Dockerfile verification (couldn't build locally with OrbStack down). Full suite **95 green**; ruff clean; gitleaks validated locally (only the gitignored `.env`/cache flagged, absent in CI).