### PR TITLE
feat(sentiment): structured-output schema, TTL cache, rate limit, temp=0 (R13)

### DIFF
--- a/src/energex/analysis/market_sentiment.py
+++ b/src/energex/analysis/market_sentiment.py
@@ -2,14 +2,43 @@
 
 import json
 import logging
-from typing import Literal
+import time
+from typing import Any, Literal
 
 import polars as pl
+from pydantic import BaseModel, Field, field_validator
 
 from energex.config import get_settings
 from energex.exceptions import AnalysisError, LLMProviderError
 from energex.llm_providers import BaseLLMProvider, LLMProviderFactory
 from energex.news_fetcher import NewsAPISource, NewsFetcher, NewsSource, RSSNewsSource
+from energex.rate_limiter import RateLimiter
+
+
+class SentimentResult(BaseModel):
+    """Validated, clamped sentiment output (structured-output schema)."""
+
+    sentiment_score: float = 0.0
+    confidence: float = 0.5
+    impact_sector: str = "General"
+    trade_signal: Literal["LONG", "SHORT", "NEUTRAL"] = "NEUTRAL"
+    key_factors: list[str] = Field(default_factory=list)
+
+    @field_validator("sentiment_score")
+    @classmethod
+    def _clamp_score(cls, v: float) -> float:
+        return max(-1.0, min(1.0, float(v)))
+
+    @field_validator("confidence")
+    @classmethod
+    def _clamp_confidence(cls, v: float) -> float:
+        return max(0.0, min(1.0, float(v)))
+
+    @field_validator("trade_signal", mode="before")
+    @classmethod
+    def _normalize_signal(cls, v: object) -> str:
+        s = str(v).upper()
+        return s if s in ("LONG", "SHORT", "NEUTRAL") else "NEUTRAL"
 
 
 class MarketSentimentAnalyzer:
@@ -79,8 +108,12 @@ class MarketSentimentAnalyzer:
 
         self.news_fetcher = NewsFetcher(news_sources)
 
-        # Simple dict-based cache for LLM responses (avoids lru_cache memory leak on methods)
-        self._sentiment_cache: dict[str, dict[str, any]] = {}  # type: ignore
+        # TTL cache for LLM responses: key -> (result, inserted_at). _clock is overridable
+        # in tests. Replaces the previous unbounded dict that ignored cache_ttl.
+        self._sentiment_cache: dict[str, tuple[dict[str, Any], float]] = {}
+        self._cache_ttl = self.settings.llm.cache_ttl
+        self._clock = time.monotonic
+        self._rate_limiter = RateLimiter(max_calls=self.settings.llm.requests_per_minute, period=60)
 
         # System prompt for LLM
         self.system_prompt = """You are a senior energy derivatives trader analyzing market news.
@@ -186,45 +219,29 @@ Only output valid JSON, nothing else."""
         self.logger.info(f"Generated sentiment for {len(sentiment_df)} article-symbol pairs")
         return sentiment_df
 
-    def _analyze_article(self, title: str, summary: str | None) -> dict[str, any]:  # type: ignore
+    def _analyze_article(self, title: str, summary: str | None) -> dict[str, Any]:
+        """Analyze a single article with the LLM, with TTL caching and rate limiting.
+
+        Returns a validated/clamped sentiment dict; degrades to the rule-based fallback
+        if the LLM is unavailable or returns a malformed response.
         """
-        Analyze a single article with LLM (with caching).
-
-        Uses instance-level dict cache to avoid memory leaks from lru_cache on methods.
-
-        Args:
-            title: Article headline.
-            summary: Article summary/description.
-
-        Returns:
-            Dictionary with sentiment analysis results.
-        """
-        # Check cache first
         cache_key = f"{title}::{summary}"
-        if cache_key in self._sentiment_cache:
-            return self._sentiment_cache[cache_key]
-        # Use LLM if available
+        cached = self._sentiment_cache.get(cache_key)
+        if cached is not None:
+            result, inserted_at = cached
+            if self._clock() - inserted_at < self._cache_ttl:
+                return result
+
         if self.llm and self.llm.is_available():
             try:
                 user_prompt = f"Headline: {title}\nSummary: {summary or 'N/A'}"
-                response = self.llm.generate_completion(self.system_prompt, user_prompt)
+                # Apply the configured rate limit to the LLM call.
+                generate = self._rate_limiter(self.llm.generate_completion)
+                response = generate(self.system_prompt, user_prompt)
 
-                # Parse JSON response
-                analysis = json.loads(response)
-
-                # Validate and normalize
-                result = {
-                    "sentiment_score": float(
-                        max(-1.0, min(1.0, analysis.get("sentiment_score", 0.0)))
-                    ),
-                    "confidence": float(max(0.0, min(1.0, analysis.get("confidence", 0.5)))),
-                    "impact_sector": str(analysis.get("impact_sector", "General")),
-                    "trade_signal": str(analysis.get("trade_signal", "NEUTRAL")).upper(),
-                    "key_factors": list(analysis.get("key_factors", [])),
-                }
-
-                # Cache the result
-                self._sentiment_cache[cache_key] = result
+                # Validate + clamp via the structured-output schema.
+                result = SentimentResult.model_validate(json.loads(response)).model_dump()
+                self._sentiment_cache[cache_key] = (result, self._clock())
                 return result
 
             except (json.JSONDecodeError, LLMProviderError, TypeError, ValueError, KeyError) as e:
@@ -234,10 +251,10 @@ Only output valid JSON, nothing else."""
 
         # Fallback: simple rule-based sentiment
         result = self._rule_based_sentiment(title, summary)
-        self._sentiment_cache[cache_key] = result
+        self._sentiment_cache[cache_key] = (result, self._clock())
         return result
 
-    def _rule_based_sentiment(self, title: str, summary: str | None) -> dict[str, any]:  # type: ignore
+    def _rule_based_sentiment(self, title: str, summary: str | None) -> dict[str, Any]:
         """
         Simple rule-based sentiment analysis fallback.
 
@@ -430,7 +447,7 @@ Only output valid JSON, nothing else."""
         self.logger.info(f"Added sentiment to {len(result)} price rows")
         return result
 
-    def get_sentiment_summary(self, sentiment_df: pl.DataFrame) -> dict[str, any]:  # type: ignore
+    def get_sentiment_summary(self, sentiment_df: pl.DataFrame) -> dict[str, Any]:
         """
         Get summary statistics of sentiment analysis.
 
@@ -500,7 +517,7 @@ Only output valid JSON, nothing else."""
                 "neutral": neutral,
                 "bearish": bearish,
             },
-            "avg_confidence": float(sentiment_df["confidence"].mean()),
+            "avg_confidence": float(sentiment_df["confidence"].mean() or 0.0),
             "date_range": [
                 sentiment_df["Datetime"].min(),
                 sentiment_df["Datetime"].max(),

--- a/src/energex/llm_providers.py
+++ b/src/energex/llm_providers.py
@@ -96,7 +96,7 @@ class OpenAIProvider(BaseLLMProvider):
                     {"role": "user", "content": user_prompt},
                 ],
                 response_format={"type": "json_object"},
-                temperature=0.3,
+                temperature=0,
             )
             content = response.choices[0].message.content
             if content is None:
@@ -151,7 +151,7 @@ class AnthropicProvider(BaseLLMProvider):
                 max_tokens=1024,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_prompt}],
-                temperature=0.3,
+                temperature=0,
             )
 
             # Extract text content from response

--- a/tests/test_sentiment_hardening.py
+++ b/tests/test_sentiment_hardening.py
@@ -1,0 +1,79 @@
+"""Tests for sentiment hardening: structured schema, TTL cache, rate limit, temp=0 (R13)."""
+
+import types
+from datetime import datetime, timezone
+
+import polars as pl
+
+from energex.analysis.market_sentiment import MarketSentimentAnalyzer, SentimentResult
+from energex.config import get_settings
+
+
+def _prices() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "Datetime": [datetime(2024, 1, 2, 12, tzinfo=timezone.utc)],
+            "Symbol": ["CL=F"],
+            "Open": [1.0],
+            "High": [1.0],
+            "Low": [1.0],
+            "Close": [1.0],
+            "Volume": [1],
+        }
+    )
+
+
+def test_sentiment_result_clamps_out_of_range():
+    r = SentimentResult(sentiment_score=5.0, confidence=2.0)
+    assert r.sentiment_score == 1.0
+    assert r.confidence == 1.0
+    r2 = SentimentResult(sentiment_score=-9.0, confidence=-1.0)
+    assert r2.sentiment_score == -1.0
+    assert r2.confidence == 0.0
+
+
+def test_sentiment_result_normalizes_trade_signal():
+    assert SentimentResult(trade_signal="long").trade_signal == "LONG"
+    assert SentimentResult(trade_signal="garbage").trade_signal == "NEUTRAL"
+
+
+def test_rate_limiter_configured_from_settings():
+    analyzer = MarketSentimentAnalyzer(_prices())
+    assert analyzer._rate_limiter.max_calls == get_settings().llm.requests_per_minute
+
+
+def test_ttl_cache_expires_and_recomputes():
+    analyzer = MarketSentimentAnalyzer(_prices())
+    analyzer.llm = None  # force deterministic rule-based path
+    clock = {"t": 0.0}
+    analyzer._clock = lambda: clock["t"]
+    analyzer._cache_ttl = 100
+
+    first = analyzer._analyze_article("Oil prices climb", "summary")
+    assert len(analyzer._sentiment_cache) == 1
+
+    clock["t"] = 50.0  # within TTL -> served from cache
+    assert analyzer._analyze_article("Oil prices climb", "summary") == first
+
+    clock["t"] = 250.0  # past TTL -> entry refreshed (still one key)
+    analyzer._analyze_article("Oil prices climb", "summary")
+    assert len(analyzer._sentiment_cache) == 1
+
+
+def test_openai_provider_uses_temperature_zero(monkeypatch):
+    from energex.llm_providers import OpenAIProvider
+
+    captured: dict = {}
+
+    class _Completions:
+        @staticmethod
+        def create(**kwargs):
+            captured.update(kwargs)
+            msg = types.SimpleNamespace(content='{"sentiment_score": 0.1, "confidence": 0.5}')
+            return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg)])
+
+    fake_client = types.SimpleNamespace(chat=types.SimpleNamespace(completions=_Completions()))
+    provider = OpenAIProvider(api_key="k")
+    monkeypatch.setattr(provider, "_get_client", lambda: fake_client)
+    provider.generate_completion("sys", "user")
+    assert captured["temperature"] == 0


### PR DESCRIPTION
**Phase 4 (ASSESSMENT.md R13).** Hardens the (now-correct) sentiment pipeline.

- **`SentimentResult`** — a Pydantic **structured-output schema** that validates + **clamps** the LLM JSON (`sentiment_score`→[-1,1], `confidence`→[0,1], `trade_signal` normalized); `_analyze_article` validates via `model_validate` instead of ad-hoc `max/min`.
- **TTL cache** — the unbounded response dict is replaced by a `(result, inserted_at)` cache honoring `settings.llm.cache_ttl` (clock injectable for tests).
- **Rate limiting** — LLM calls go through `RateLimiter(settings.llm.requests_per_minute)` (previously dead code).
- **`temperature=0`** in the OpenAI/Anthropic providers → reproducible, backtestable sentiment.

Tests: schema clamps + normalizes; TTL cache expires; rate limiter configured from settings; OpenAI provider sends `temperature=0`. Full suite **103 green**; ruff clean.

A local FinBERT/FinGPT fallback and a gold-set / event-study evaluation harness remain documented future work (heavy ML deps).