### PR TITLE
feat(sentiment): local Ollama/gemma3:4b as default LLM + /sentiment endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,18 +14,21 @@ ANTHROPIC_API_KEY=sk-ant-your-anthropic-api-key-here
 # Example models: claude-3-5-sonnet-20241022, claude-3-opus-20240229, claude-3-haiku-20240307
 
 # Local LLM Configuration (Ollama)
+# Host runs:  ollama serve  +  ollama pull gemma3:4b
+# From a container, use http://host.docker.internal:11434 instead of localhost.
 OLLAMA_BASE_URL=http://localhost:11434
-# Example models: llama3, mistral, mixtral, codellama
+# Example models: gemma3:4b, gemma3:12b, llama3, mistral
 
 # =============================================================================
 # Default LLM Settings
 # =============================================================================
 
 # Which provider to use by default (options: openai, anthropic, ollama)
-DEFAULT_LLM_PROVIDER=openai
+# Default to the local Ollama model so sentiment runs offline with no API keys.
+DEFAULT_LLM_PROVIDER=ollama
 
 # Model name for the chosen provider
-DEFAULT_LLM_MODEL=gpt-4
+DEFAULT_LLM_MODEL=gemma3:4b
 
 # Rate limiting for LLM API calls (requests per minute)
 LLM_REQUESTS_PER_MINUTE=10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
       TZ: America/Chicago
       LOG_LEVEL: INFO
       ENERGEX_INGEST_CRON: "*/5 * * * *"
+      # Local LLM via Ollama (gemma3:4b). Reaches the host's Ollama from the container.
+      DEFAULT_LLM_PROVIDER: ollama
+      DEFAULT_LLM_MODEL: gemma3:4b
+      OLLAMA_BASE_URL: http://host.docker.internal:11434
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "8000:8000"
     volumes:

--- a/src/energex/analysis/market_sentiment.py
+++ b/src/energex/analysis/market_sentiment.py
@@ -219,6 +219,11 @@ Only output valid JSON, nothing else."""
         self.logger.info(f"Generated sentiment for {len(sentiment_df)} article-symbol pairs")
         return sentiment_df
 
+    def analyze_headline(self, title: str, summary: str | None = None) -> dict[str, Any]:
+        """Analyze a single headline with the configured LLM (TTL-cached, rate-limited),
+        falling back to rule-based sentiment if the LLM is unavailable."""
+        return self._analyze_article(title, summary)
+
     def _analyze_article(self, title: str, summary: str | None) -> dict[str, Any]:
         """Analyze a single article with the LLM, with TTL caching and rate limiting.
 

--- a/src/energex/service/app.py
+++ b/src/energex/service/app.py
@@ -8,6 +8,7 @@ import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from typing import Any
 
 import polars as pl
@@ -15,6 +16,7 @@ from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
 from energex.analysis.futures import FuturesAnalyzer
+from energex.analysis.market_sentiment import MarketSentimentAnalyzer
 from energex.analysis.volatility import VolatilityAnalyzer
 from energex.config import get_settings
 from energex.database import EnergyDatabase
@@ -116,6 +118,19 @@ def create_app(db_path: str | None = None, start_scheduler: bool = True) -> Fast
             raise HTTPException(status_code=404, detail="no data for the requested symbols")
         out = FuturesAnalyzer(df).calculate_term_structure(front, back)
         return out.select(["Datetime", "spread", "spread_pct"]).to_dicts()
+
+    @app.get("/sentiment")
+    def sentiment(headline: str = Query(...), summary: str | None = None) -> dict[str, Any]:
+        # The provider comes from config (set DEFAULT_LLM_PROVIDER=ollama +
+        # DEFAULT_LLM_MODEL=gemma3:4b + OLLAMA_BASE_URL for the local model).
+        placeholder = pl.DataFrame(
+            {"Symbol": ["CL=F"], "Datetime": [datetime(2024, 1, 1, tzinfo=timezone.utc)]}
+        )
+        analyzer = MarketSentimentAnalyzer(placeholder)
+        result = analyzer.analyze_headline(headline, summary)
+        provider = type(analyzer.llm).__name__ if analyzer.llm else "rule-based"
+        available = bool(analyzer.llm and analyzer.llm.is_available())
+        return {"provider": provider, "llm_available": available, "sentiment": result}
 
     @app.get("/charts/price/{symbol}", response_class=HTMLResponse)
     def price_chart(symbol: str) -> str:

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -122,3 +122,12 @@ def test_malformed_numeric_field_does_not_abort():
     analyzer.llm = TypeErrorLLM()  # type: ignore[assignment]
     result = analyzer._analyze_article("Gas falls", "summary")
     assert result["key_factors"] == ["Rule-based analysis"]
+
+
+def test_analyze_headline_falls_back_to_rule_based():
+    prices = _prices(["CL=F"], [datetime(2024, 1, 2, 12, tzinfo=timezone.utc)])
+    analyzer = MarketSentimentAnalyzer(prices)
+    analyzer.llm = None  # no LLM -> rule-based
+    result = analyzer.analyze_headline("Oil prices surge on OPEC production cuts")
+    assert result["trade_signal"] == "LONG"
+    assert result["sentiment_score"] > 0

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -118,3 +118,24 @@ def test_run_ingestion_upserts(monkeypatch, tmp_db_path):
     db.conn.close()
     assert n == 1
     assert count == 1
+
+
+def test_sentiment_endpoint_returns_analysis(client, monkeypatch):
+    from energex.analysis.market_sentiment import MarketSentimentAnalyzer
+
+    monkeypatch.setattr(
+        MarketSentimentAnalyzer,
+        "analyze_headline",
+        lambda self, title, summary=None: {
+            "sentiment_score": 0.7,
+            "confidence": 0.9,
+            "impact_sector": "Oil",
+            "trade_signal": "LONG",
+            "key_factors": ["OPEC cuts"],
+        },
+    )
+    r = client.get("/sentiment", params={"headline": "Oil prices rise"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["sentiment"]["trade_signal"] == "LONG"
+    assert "provider" in body and "llm_available" in body


### PR DESCRIPTION
Wires the **local model** (Ollama `gemma3:4b`) as the default LLM so sentiment runs offline with no API keys, and exposes it in the running service.

- **Config**: `docker-compose.yml` sets `DEFAULT_LLM_PROVIDER=ollama`, `DEFAULT_LLM_MODEL=gemma3:4b`, `OLLAMA_BASE_URL=http://host.docker.internal:11434` (+ `extra_hosts: host-gateway` so the container reaches the host's Ollama); `.env.example` documents the same.
- **`MarketSentimentAnalyzer.analyze_headline()`**: public single-headline entrypoint.
- **`GET /sentiment?headline=...`**: runs the analyzer via the configured provider (gemma by default) and returns the validated sentiment + provider/availability.

### Verified live on OrbStack
`docker compose up -d --build` → container `Up (healthy)`; `GET /healthz` → 200; `GET /sentiment` → `{provider: OllamaProvider, llm_available: true, sentiment: {score 0.8, LONG, ...}}` — real gemma3:4b output (bullish→0.8/LONG, bearish→-0.8/SHORT), not the rule-based fallback.

Full suite **105 green**; ruff clean; compose validates.