### PR TITLE
fix: resolve all 28 findings from the refinement audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,15 +106,20 @@ LOG_LEVEL=INFO
 # LOG_FILE=energex.log
 LOG_ENABLE_CONSOLE=true
 
-# =============================================================================
-# Legacy service (the compose `energex` FastAPI container)
-# =============================================================================
-# Path to the legacy DuckDB read-path database inside the container.
-ENERGEX_DB_PATH=/data/energy.db
-# Container timezone and the legacy ingest cron cadence.
+# Container timezone.
 TZ=America/Chicago
-ENERGEX_INGEST_CRON=*/5 * * * *
 
-# Legacy news sources for the optional sentiment analyzer (reserved).
+# =============================================================================
+# S2 read API (the compose `api` service on :8000)
+# =============================================================================
+# When set, every data endpoint (/series, /curve, /symbols, /libraries) requires a matching
+# X-API-Key header. Leave unset to run open (a startup warning is logged); /healthz stays open.
+# ENERGEX_READ_API_KEY=change-me-read-api-key
+# Comma-separated CORS allow-list (e.g. the frontend origin); unset = no cross-origin access.
+# ENERGEX_CORS_ORIGINS=http://localhost:5173
+# Max rows an unbounded /series read may return before 413 (narrow with start/end instead).
+# ENERGEX_SERIES_MAX_ROWS=500000
+
+# News sources for the optional sentiment analyzer (reserved).
 # NEWS_API_KEY=your-newsapi-key-here
 # ALPHA_VANTAGE_KEY=your-alpha-vantage-key-here

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,9 +2,10 @@
 useDefault = true
 
 [allowlist]
-description = "Test fixtures use obviously-fake placeholder credentials."
+# Narrowly scoped (no blanket tests/ ignore) so a real secret committed under tests/ is still
+# caught; test fixtures use obvious low-entropy fakes the default rules do not flag.
+description = "Placeholder-credential example files and tool caches."
 paths = [
-  '''tests/.*''',
   '''\.env\.example''',
   '''\.mypy_cache/.*''',
   '''\.ruff_cache/.*''',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       MINIO_ENDPOINT: minio:9000
       ARCTIC_BUCKET: ${ARCTIC_BUCKET:-arctic}
       # Scoped ArcticDB service account created by minio-init (NOT MinIO root); read-only API.
-      MINIO_ACCESS_KEY: ${ARCTIC_ACCESS_KEY:-energex-arctic}
-      MINIO_SECRET_KEY: ${ARCTIC_SECRET_KEY:-energex-arctic-secret}
+      MINIO_ACCESS_KEY: ${ARCTIC_ACCESS_KEY:?set ARCTIC_ACCESS_KEY in .env}
+      MINIO_SECRET_KEY: ${ARCTIC_SECRET_KEY:?set ARCTIC_SECRET_KEY in .env}
       TZ: UTC
     ports:
       - "8000:8001"
@@ -79,8 +79,8 @@ services:
     mem_limit: 1g
     cpus: 1.0
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env}
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -110,10 +110,10 @@ services:
       minio:
         condition: service_healthy
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
-      ARCTIC_ACCESS_KEY: ${ARCTIC_ACCESS_KEY:-energex-arctic}
-      ARCTIC_SECRET_KEY: ${ARCTIC_SECRET_KEY:-energex-arctic-secret}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env}
+      ARCTIC_ACCESS_KEY: ${ARCTIC_ACCESS_KEY:?set ARCTIC_ACCESS_KEY in .env}
+      ARCTIC_SECRET_KEY: ${ARCTIC_SECRET_KEY:?set ARCTIC_SECRET_KEY in .env}
     volumes:
       - ./deploy/minio:/policies:ro
     entrypoint: >
@@ -182,8 +182,8 @@ services:
       MINIO_ENDPOINT: minio:9000
       ARCTIC_BUCKET: ${ARCTIC_BUCKET:-arctic}
       # Scoped ArcticDB service account created by minio-init (NOT MinIO root).
-      MINIO_ACCESS_KEY: ${ARCTIC_ACCESS_KEY:-energex-arctic}
-      MINIO_SECRET_KEY: ${ARCTIC_SECRET_KEY:-energex-arctic-secret}
+      MINIO_ACCESS_KEY: ${ARCTIC_ACCESS_KEY:?set ARCTIC_ACCESS_KEY in .env}
+      MINIO_SECRET_KEY: ${ARCTIC_SECRET_KEY:?set ARCTIC_SECRET_KEY in .env}
       # Entity graph (Neo4jResource forward-compat).
       NEO4J_URI: bolt://neo4j:7687
       NEO4J_USER: neo4j
@@ -240,8 +240,8 @@ services:
       MINIO_ENDPOINT: minio:9000
       ARCTIC_BUCKET: ${ARCTIC_BUCKET:-arctic}
       # Scoped ArcticDB service account created by minio-init (NOT MinIO root).
-      MINIO_ACCESS_KEY: ${ARCTIC_ACCESS_KEY:-energex-arctic}
-      MINIO_SECRET_KEY: ${ARCTIC_SECRET_KEY:-energex-arctic-secret}
+      MINIO_ACCESS_KEY: ${ARCTIC_ACCESS_KEY:?set ARCTIC_ACCESS_KEY in .env}
+      MINIO_SECRET_KEY: ${ARCTIC_SECRET_KEY:?set ARCTIC_SECRET_KEY in .env}
       # Entity graph (Neo4jResource forward-compat).
       NEO4J_URI: bolt://neo4j:7687
       NEO4J_USER: neo4j
@@ -277,7 +277,7 @@ services:
     mem_limit: 2g
     cpus: 1.5
     environment:
-      NEO4J_AUTH: ${NEO4J_AUTH:-neo4j/energex-neo4j}
+      NEO4J_AUTH: ${NEO4J_AUTH:?set NEO4J_AUTH in .env}
       NEO4J_server_memory_heap_initial__size: "512m"
       NEO4J_server_memory_heap_max__size: "512m"
       NEO4J_server_memory_pagecache_size: "512m"

--- a/src/energex/__init__.py
+++ b/src/energex/__init__.py
@@ -47,15 +47,22 @@ Configuration:
 For more examples, see: src/examples/
 """
 
-# Load the repo-root .env for local runs so nested sub-configs (e.g. ConnectorConfig)
-# that read os.environ-only see credentials. Skipped under pytest to preserve the
-# offline tests' no-creds invariant; deployment injects env via docker-compose.
-import sys
+# Load the repo-root .env for local runs so every config — including nested sub-configs that
+# read os.environ only (e.g. ConnectorConfig) — resolves credentials uniformly through
+# os.environ, with real environment variables always taking precedence (load_dotenv never
+# overrides an existing var). The path is resolved relative to THIS package, never via a
+# CWD/parent-directory search (so a REPL/debugger cannot bind an unintended parent .env). The
+# load is skipped when ENERGEX_SKIP_DOTENV=1 (the test suite sets this to preserve its
+# no-credentials invariant); the deployment injects env via docker-compose and ships no .env.
+import os
+from pathlib import Path
 
-if "pytest" not in sys.modules:
+if os.environ.get("ENERGEX_SKIP_DOTENV") != "1":
     from dotenv import load_dotenv
 
-    load_dotenv()
+    _dotenv_path = Path(__file__).resolve().parents[2] / ".env"
+    if _dotenv_path.is_file():
+        load_dotenv(_dotenv_path)
 
 # Pin ArcticDB's vendored AWS C SDK ahead of pyarrow's (phase-0 load-order hazard):
 # whichever of libarrow / arcticdb_ext loads first wins the AWS symbols, and if

--- a/src/energex/core/config.py
+++ b/src/energex/core/config.py
@@ -146,9 +146,6 @@ class ConnectorConfig(BaseSettings):
         default=None,
         validation_alias=AliasChoices("ERCOT_API_KEY_PRIMARY", "ERCOT_SUBSCRIPTION_KEY"),
     )
-    ercot_subscription_key_secondary: SecretStr | None = Field(
-        default=None, validation_alias="ERCOT_API_KEY_SECONDARY"
-    )
     noaa_token: SecretStr | None = Field(default=None, validation_alias="NOAA_TOKEN")
 
     model_config = SettingsConfigDict(case_sensitive=False, populate_by_name=True)

--- a/src/energex/core/connectors/ercot.py
+++ b/src/energex/core/connectors/ercot.py
@@ -21,11 +21,11 @@ from typing import Any
 
 import httpx
 import pandas as pd
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from energex.core.config import get_settings
 from energex.core.connectors.base import FetchResult
-from energex.core.exceptions import ConfigurationError
+from energex.core.exceptions import ConfigurationError, DataFetchError
 
 logger = logging.getLogger(__name__)
 
@@ -61,22 +61,47 @@ _SETTLEMENT_POINTS = frozenset(
 )
 
 
-def _cpt_hour_ending_to_utc(days: pd.Series, minutes: pd.Series, dst_flag: pd.Series) -> pd.Series:
-    """(operating day, minutes-after-midnight hour-ending, DSTFlag) -> tz-aware UTC.
+def _is_retryable(exc: BaseException) -> bool:
+    """Retry only transient failures: transport/timeout errors and 5xx responses. Never retry
+    4xx (bad creds, bad request) — retrying those just hammers ERCOT's auth/API and risks
+    lockout without ever succeeding."""
+    if isinstance(exc, httpx.TransportError):  # includes TimeoutException, ConnectError, etc.
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code >= 500
+    return False
 
-    ``days`` is date-like; ``minutes`` is minutes after local midnight of the interval-/
-    hour-ending instant; ``dst_flag`` True marks the DST occurrence of the duplicated
-    fall-back hour. Localize to Central Prevailing Time, then convert to UTC.
+
+def _cpt_hour_ending_to_utc(
+    days: pd.Series, end_minutes: pd.Series, dst_flag: pd.Series, duration_minutes: int
+) -> pd.Series:
+    """(operating day, minutes-after-midnight of the interval END, DSTFlag, interval length)
+    -> tz-aware UTC instant of the interval end.
+
+    ERCOT times are Central Prevailing Time, hour-ending. On the fall-back day the 01:00-02:00
+    hour repeats; ERCOT marks the daylight (CDT) repeat with DSTFlag=Y and the standard (CST)
+    repeat with DSTFlag=N (verified against a real fall-back-day payload). Only the 01:00-01:59
+    *beginning* wall instants are ambiguous to pandas, so we localize the interval BEGINNING
+    (``end_minutes - duration``) with ``ambiguous=DSTFlag`` (pandas ``ambiguous=True`` selects the
+    earlier/DST occurrence, matching DSTFlag=Y), then add the duration in absolute time.
+    Localizing the END instant instead would leave 02:00 unambiguous and silently collapse the
+    two repeated hours onto a single UTC timestamp.
     """
-    naive = pd.to_datetime(days) + pd.to_timedelta(minutes.astype(int), unit="m")
+    end_minutes = pd.to_numeric(end_minutes, errors="coerce")
+    begin = pd.to_datetime(days) + pd.to_timedelta(end_minutes - duration_minutes, unit="m")
     ambiguous = dst_flag.astype(bool).to_numpy()
-    local = naive.dt.tz_localize(_CPT, ambiguous=ambiguous, nonexistent="shift_forward")
-    return local.dt.tz_convert("UTC")
+    local_begin = begin.dt.tz_localize(_CPT, ambiguous=ambiguous, nonexistent="shift_forward")
+    return (local_begin + pd.Timedelta(minutes=duration_minutes)).dt.tz_convert("UTC")
 
 
 def _hour_ending_to_minutes(hour_ending: pd.Series) -> pd.Series:
-    """ERCOT hourEnding string ('01:00'..'24:00') -> minutes after midnight (60..1440)."""
-    return hour_ending.astype(str).str.split(":").str[0].astype(int) * 60
+    """ERCOT hourEnding string ('01:00'..'24:00') -> minutes after midnight (60..1440).
+
+    Coerces unparseable values to NaN (which become NaT valid_time and are rejected loudly by
+    the non-null quality gate) rather than raising on a single malformed row.
+    """
+    hours = pd.to_numeric(hour_ending.astype(str).str.split(":").str[0], errors="coerce")
+    return hours * 60
 
 
 def _empty_spp() -> pd.DataFrame:
@@ -111,6 +136,13 @@ def _finalize_spp(prefix: str, raw: pd.DataFrame, valid_time: pd.Series) -> pd.D
             "price": pd.to_numeric(raw["settlementPointPrice"], errors="coerce").astype("float64"),
         }
     )
+    drift = {p for p in sp.unique() if p.startswith(("HB_", "LZ_"))} - set(_SETTLEMENT_POINTS)
+    if drift:
+        logger.warning(
+            "ERCOT: hub/load-zone settlement points seen but not in the curated allowlist "
+            "(possible drift — review _SETTLEMENT_POINTS): %s",
+            sorted(drift),
+        )
     out = out[out["settlement_point"].isin(_SETTLEMENT_POINTS)]
     out = out.dropna(subset=["price"])
     out = out.drop_duplicates(subset=["instrument_id", "valid_time"], keep="last")
@@ -165,6 +197,7 @@ class _ErcotConnector:
         @retry(
             stop=stop_after_attempt(self._retries),
             wait=wait_exponential(multiplier=1, max=10),
+            retry=retry_if_exception(_is_retryable),
             reraise=True,
         )
         def _go() -> str:
@@ -194,11 +227,23 @@ class _ErcotConnector:
         page = 1
         while True:
             body = self._get(client, url, headers, {**params, "size": _PAGE_SIZE, "page": page})
-            if not fields:
-                fields = [f["name"] for f in body.get("fields", [])]
-            rows.extend(body.get("data", []))
-            total_pages = int(body.get("_meta", {}).get("totalPages", page))
-            if page >= total_pages:
+            batch = body.get("data", [])
+            page_fields = body.get("fields")
+            if page_fields:
+                fields = [f["name"] for f in page_fields]
+            elif batch and not fields:
+                # data rows with no column schema would silently vanish in the DataFrame build.
+                raise DataFetchError(
+                    f"ERCOT {self.report_path}: response carried data rows but no 'fields' schema"
+                )
+            rows.extend(batch)
+            total_pages = body.get("_meta", {}).get("totalPages")
+            if total_pages is not None:
+                if page >= int(total_pages):
+                    break
+            elif len(batch) < _PAGE_SIZE:
+                # No pagination metadata: a short page means the end; a full page means keep going
+                # (stopping here would silently truncate; looping forever is avoided by the floor).
                 break
             page += 1
         return pd.DataFrame(rows, columns=fields) if fields else pd.DataFrame()
@@ -207,6 +252,7 @@ class _ErcotConnector:
         @retry(
             stop=stop_after_attempt(self._retries),
             wait=wait_exponential(multiplier=1, max=10),
+            retry=retry_if_exception(_is_retryable),
             reraise=True,
         )
         def _go() -> dict:
@@ -220,7 +266,13 @@ class _ErcotConnector:
         user, pwd, key = self._creds()  # fail-fast before any network call
         fetched_at = datetime.now(timezone.utc)
         owns_client = self._client is None
-        client = httpx.Client(timeout=self._timeout) if owns_client else self._client
+        # follow_redirects=False so a 30x cannot silently move the credentialed request
+        # (bearer token + subscription key) to an off-host location.
+        client = (
+            httpx.Client(timeout=self._timeout, follow_redirects=False)
+            if owns_client
+            else self._client
+        )
         try:
             token = self._token(client, user, pwd)
             raw = self._collect(client, token, key, window_start, window_end)
@@ -263,10 +315,12 @@ class ErcotRtSppConnector(_ErcotConnector):
     def _shape(self, raw: pd.DataFrame) -> pd.DataFrame:
         if raw.empty:
             return _empty_spp()
-        minutes = (raw["deliveryHour"].astype(int) - 1) * 60 + raw["deliveryInterval"].astype(
-            int
-        ) * 15
-        valid_time = _cpt_hour_ending_to_utc(raw["deliveryDate"], minutes, raw["DSTFlag"])
+        hour = pd.to_numeric(raw["deliveryHour"], errors="coerce")
+        interval = pd.to_numeric(raw["deliveryInterval"], errors="coerce")
+        end_minutes = (
+            hour - 1
+        ) * 60 + interval * 15  # 15-min interval-ending, minutes past midnight
+        valid_time = _cpt_hour_ending_to_utc(raw["deliveryDate"], end_minutes, raw["DSTFlag"], 15)
         return _finalize_spp("ERCOT.SPP.", raw, valid_time)
 
 
@@ -278,8 +332,8 @@ class ErcotDamSppConnector(_ErcotConnector):
     def _shape(self, raw: pd.DataFrame) -> pd.DataFrame:
         if raw.empty:
             return _empty_spp()
-        minutes = _hour_ending_to_minutes(raw["hourEnding"])
-        valid_time = _cpt_hour_ending_to_utc(raw["deliveryDate"], minutes, raw["DSTFlag"])
+        end_minutes = _hour_ending_to_minutes(raw["hourEnding"])
+        valid_time = _cpt_hour_ending_to_utc(raw["deliveryDate"], end_minutes, raw["DSTFlag"], 60)
         return _finalize_spp("ERCOT.DASPP.", raw, valid_time)
 
 
@@ -295,11 +349,13 @@ class ErcotLoadConnector(_ErcotConnector):
         cols = ["instrument_id", "valid_time", "value"]
         if raw.empty:
             return _empty_load()
-        minutes = _hour_ending_to_minutes(raw["hourEnding"])
+        end_minutes = _hour_ending_to_minutes(raw["hourEnding"])
         out = pd.DataFrame(
             {
                 "instrument_id": "ERCOT.LOAD.ERCOT",
-                "valid_time": _cpt_hour_ending_to_utc(raw["operatingDay"], minutes, raw["DSTFlag"]),
+                "valid_time": _cpt_hour_ending_to_utc(
+                    raw["operatingDay"], end_minutes, raw["DSTFlag"], 60
+                ),
                 "value": pd.to_numeric(raw["total"], errors="coerce").astype("float64"),
             }
         )

--- a/src/energex/core/storage.py
+++ b/src/energex/core/storage.py
@@ -136,6 +136,22 @@ def _empty_like(lib, symbol, idx):
     return lib.read(symbol, as_of=int(v)).data.iloc[0:0]
 
 
+# Per-commit provenance columns; identical underlying data under a new as_of is NOT new
+# knowledge, so these are excluded when deciding whether a commit changes the payload.
+_PROVENANCE_COLS = ("as_of", "source", "source_url", "fetched_at", "vintage_reconstructed")
+
+
+def _same_payload(new, prior) -> bool:
+    """True iff two canonical frames carry identical data (index + non-provenance columns)."""
+    if prior is None:
+        return False
+    a = new.drop(columns=[c for c in _PROVENANCE_COLS if c in new.columns])
+    b = prior.drop(columns=[c for c in _PROVENANCE_COLS if c in prior.columns])
+    if list(a.columns) != list(b.columns) or len(a) != len(b):
+        return False
+    return a.equals(b)
+
+
 # ---------------------------------------------------------------- commit / read
 def commit_vintage(
     lib,
@@ -160,6 +176,15 @@ def commit_vintage(
     if mode == "bitemporal_merge":
         prior = _read_full_series_before(lib, symbol, idx, a)
         cframe = _merge_revisions(prior, cframe)
+    # Content idempotency: if this commit's payload matches the latest committed vintage, a
+    # re-record under a new as_of adds no knowledge — skip it. Without this, an unchanged hourly
+    # re-pull (the ERCOT case) creates a fresh full-history vintage every run (unbounded growth).
+    if not force:
+        latest_v = _latest_committed_version(idx)
+        if latest_v is not None and _same_payload(
+            cframe, lib.read(symbol, as_of=int(latest_v)).data
+        ):
+            return int(latest_v)
     v = lib.write(
         symbol,
         cframe,
@@ -175,7 +200,8 @@ def commit_vintage(
         vintage_reconstructed=reconstructed,
     )
     try:  # UI-only convenience snapshot; correctness never depends on it.
-        lib.snapshot(f"{symbol}@{a:%Y-%m-%dT%H%M%SZ}", versions={symbol: int(v)})
+        # Microsecond resolution so two commits within the same second cannot collide on name.
+        lib.snapshot(f"{symbol}@{a:%Y-%m-%dT%H%M%S_%fZ}", versions={symbol: int(v)})
     except Exception:
         pass
     return int(v)

--- a/src/energex/orchestration/assets.py
+++ b/src/energex/orchestration/assets.py
@@ -388,10 +388,15 @@ def eia930_generation_by_fuel(
 
 
 def _commit_ercot(
-    context: dg.AssetExecutionContext, arctic: ArcticDBResource, result, schema
+    context: dg.AssetExecutionContext, arctic: ArcticDBResource, result, schema, *, validation_as_of
 ) -> dg.MaterializeResult:
-    """Gate -> per-instrument bitemporal_merge commit for an ERCOT frame."""
-    frame = quality.validate(result.frame, schema, as_of=result.fetched_at)
+    """Gate -> per-instrument bitemporal_merge commit for an ERCOT frame.
+
+    Freshness is validated against ``validation_as_of`` (the partition's end), NOT wall-clock now,
+    so backfilling an operating day older than the freshness bound does not falsely fail the gate.
+    The bitemporal as_of/fetched_at remain the real knowledge time (``result.fetched_at``).
+    """
+    frame = quality.validate(result.frame, schema, as_of=validation_as_of)
     versions: dict[str, int] = {}
     libs: dict[str, Any] = {}
     for instrument_id, group in frame.groupby("instrument_id", sort=True):
@@ -433,9 +438,10 @@ def _commit_ercot(
 def ercot_rt_spp(
     context: dg.AssetExecutionContext, arctic: ArcticDBResource
 ) -> dg.MaterializeResult:
-    day = context.partition_time_window.start.date()
+    window = context.partition_time_window
+    day = window.start.date()
     result = ErcotRtSppConnector().fetch(day, day)
-    return _commit_ercot(context, arctic, result, schemas.ERCOT_SPP)
+    return _commit_ercot(context, arctic, result, schemas.ERCOT_SPP, validation_as_of=window.end)
 
 
 @dg.asset(
@@ -451,9 +457,10 @@ def ercot_rt_spp(
 def ercot_dam_spp(
     context: dg.AssetExecutionContext, arctic: ArcticDBResource
 ) -> dg.MaterializeResult:
-    day = context.partition_time_window.start.date()
+    window = context.partition_time_window
+    day = window.start.date()
     result = ErcotDamSppConnector().fetch(day, day)
-    return _commit_ercot(context, arctic, result, schemas.ERCOT_SPP)
+    return _commit_ercot(context, arctic, result, schemas.ERCOT_SPP, validation_as_of=window.end)
 
 
 @dg.asset(
@@ -464,9 +471,10 @@ def ercot_dam_spp(
     description="ERCOT-wide actual system load (hourly) -> power.load (bitemporal_merge).",
 )
 def ercot_load(context: dg.AssetExecutionContext, arctic: ArcticDBResource) -> dg.MaterializeResult:
-    day = context.partition_time_window.start.date()
+    window = context.partition_time_window
+    day = window.start.date()
     result = ErcotLoadConnector().fetch(day, day)
-    return _commit_ercot(context, arctic, result, schemas.ERCOT_LOAD)
+    return _commit_ercot(context, arctic, result, schemas.ERCOT_LOAD, validation_as_of=window.end)
 
 
 ASSETS: list[Any] = [

--- a/src/energex/orchestration/checks.py
+++ b/src/energex/orchestration/checks.py
@@ -229,6 +229,11 @@ def eia_petroleum_status_pass_quality_gate(arctic: ArcticDBResource) -> dg.Asset
     )
 
 
+# A power symbol lagging the freshest by more than this is flagged stale in the check metadata
+# (power feeds update at least daily; this is generous headroom for weekends/gaps).
+_STALE_SYMBOL_LAG = pd.Timedelta(days=3)
+
+
 def _power_gate_readback(
     arctic: ArcticDBResource, libraries: list[str], schema: Any, label: str
 ) -> dg.AssetCheckResult:
@@ -247,6 +252,12 @@ def _power_gate_readback(
         return dg.AssetCheckResult(passed=False, metadata={"reason": f"no {label} found"})
     frame = pd.concat(frames, ignore_index=True)
     frame["valid_time"] = pd.to_datetime(frame["valid_time"], utc=True)
+    # Per-symbol staleness: the schema freshness check uses max(valid_time) across ALL symbols,
+    # so a single symbol that stopped updating would not lower it. Surface any symbol lagging the
+    # freshest by more than the threshold in the check metadata (visible in the Dagster UI).
+    latest_by_symbol = frame.groupby("instrument_id")["valid_time"].max()
+    freshest = latest_by_symbol.max()
+    stale = sorted(latest_by_symbol.index[latest_by_symbol < freshest - _STALE_SYMBOL_LAG])
     as_of = _committed_as_of(frame)
     try:
         validated = quality.validate(frame, schema, as_of=as_of)
@@ -257,7 +268,11 @@ def _power_gate_readback(
         )
     return dg.AssetCheckResult(
         passed=True,
-        metadata={"rows": int(len(validated)), "symbols": int(frame["instrument_id"].nunique())},
+        metadata={
+            "rows": int(len(validated)),
+            "symbols": int(frame["instrument_id"].nunique()),
+            "stale_symbols": dg.MetadataValue.json(stale),
+        },
     )
 
 

--- a/src/energex/orchestration/partitions.py
+++ b/src/energex/orchestration/partitions.py
@@ -28,5 +28,10 @@ FRED_DAILY = dg.DailyPartitionsDefinition(start_date="2020-01-01")
 # revisions. The hourly schedule re-materializes the latest (today's) partition.
 EIA930_DAILY = dg.DailyPartitionsDefinition(start_date="2023-06-01")
 
-# ERCOT nodal daily partition (forward-fill; no nodal backfill this slice).
-ERCOT_DAILY = dg.DailyPartitionsDefinition(start_date="2026-06-01")
+# ERCOT nodal daily partition keyed by the ERCOT operating day (Central Prevailing Time, not
+# UTC, so a partition key maps 1:1 to an ERCOT delivery day). end_offset=2 keeps today AND
+# tomorrow as valid keys: RT/load materialize the CURRENT operating day intraday, while the DAM
+# schedule targets the NEXT day's curve that clears midday.
+ERCOT_DAILY = dg.DailyPartitionsDefinition(
+    start_date="2026-06-01", timezone="America/Chicago", end_offset=2
+)

--- a/src/energex/orchestration/schedules.py
+++ b/src/energex/orchestration/schedules.py
@@ -8,6 +8,7 @@ scheduled — Yahoo/yfinance is blocked, so a tick would only fire failing runs;
 manual.
 """
 
+from datetime import timedelta
 from typing import Any
 
 import dagster as dg
@@ -59,6 +60,22 @@ def _latest_partition_request(
     if not keys:
         return dg.SkipReason("no partition available yet")
     return dg.RunRequest(partition_key=keys[-1])
+
+
+def _ercot_day_request(
+    context: dg.ScheduleEvaluationContext,
+    partitions_def: dg.TimeWindowPartitionsDefinition,
+    *,
+    day_offset: int,
+) -> dg.RunRequest | dg.SkipReason:
+    """Target an ERCOT operating day relative to the tick (in Central time). RT/load capture the
+    CURRENT day intraday (offset 0); DAM publishes the NEXT day's curve midday (offset +1). The
+    latest-ended-partition heuristic is wrong for both — it lags a full operating day."""
+    tick = context.scheduled_execution_time  # tz-aware in execution_timezone (America/Chicago)
+    key = (tick.date() + timedelta(days=day_offset)).isoformat()
+    if key not in set(partitions_def.get_partition_keys(current_time=tick)):
+        return dg.SkipReason(f"partition {key} not in range yet")
+    return dg.RunRequest(partition_key=key)
 
 
 # EIA natural-gas weekly storage releases Thursday 10:30 ET; fire just after.
@@ -142,7 +159,7 @@ _ercot_load_job = dg.define_asset_job(
 )
 
 
-# RT SPP lands every 15 min; re-materialize the latest partition hourly.
+# RT SPP lands every 15 min; re-materialize the CURRENT operating day hourly (intraday).
 @dg.schedule(
     job=_ercot_rt_spp_job,
     cron_schedule="25 * * * *",
@@ -153,10 +170,10 @@ _ercot_load_job = dg.define_asset_job(
 def ercot_rt_spp_schedule(
     context: dg.ScheduleEvaluationContext,
 ) -> dg.RunRequest | dg.SkipReason:
-    return _latest_partition_request(context, ERCOT_DAILY)
+    return _ercot_day_request(context, ERCOT_DAILY, day_offset=0)
 
 
-# Actual system load posts hourly.
+# Actual system load posts hourly for the current operating day.
 @dg.schedule(
     job=_ercot_load_job,
     cron_schedule="35 * * * *",
@@ -167,10 +184,10 @@ def ercot_rt_spp_schedule(
 def ercot_load_schedule(
     context: dg.ScheduleEvaluationContext,
 ) -> dg.RunRequest | dg.SkipReason:
-    return _latest_partition_request(context, ERCOT_DAILY)
+    return _ercot_day_request(context, ERCOT_DAILY, day_offset=0)
 
 
-# DAM clears ~12:30-13:30 CPT for the next day; refresh once each afternoon.
+# DAM clears ~12:30-13:30 CPT for the NEXT operating day; fetch tomorrow's curve each afternoon.
 @dg.schedule(
     job=_ercot_dam_spp_job,
     cron_schedule="0 14 * * *",
@@ -181,7 +198,7 @@ def ercot_load_schedule(
 def ercot_dam_spp_schedule(
     context: dg.ScheduleEvaluationContext,
 ) -> dg.RunRequest | dg.SkipReason:
-    return _latest_partition_request(context, ERCOT_DAILY)
+    return _ercot_day_request(context, ERCOT_DAILY, day_offset=1)
 
 
 SCHEDULES: list[Any] = [

--- a/src/energex/service/readapi.py
+++ b/src/energex/service/readapi.py
@@ -13,6 +13,7 @@ app (``energex.service.app``) and APScheduler were removed; this is the S2 repla
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import os
@@ -23,7 +24,8 @@ from typing import Any
 # arcticdb MUST be imported before pandas/pyarrow (phase-0 AWS-SDK load-order hazard).
 import arcticdb  # noqa: F401
 import pandas as pd
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, Header, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
 
 from energex.core import storage, symbology
 from energex.core.config import get_settings
@@ -102,6 +104,16 @@ def _get_library(ac: Any, library: str) -> Any:
     return ac[library]
 
 
+def _require_api_key(x_api_key: str | None = Header(default=None)) -> None:
+    """Optional API-key gate. When ``ENERGEX_READ_API_KEY`` is set, every data endpoint requires
+    a matching ``X-API-Key`` header (constant-time compared); unset leaves the API open (a startup
+    warning is logged). This lets an operator lock down the host-published read API without
+    breaking same-host callers that have the key."""
+    expected = os.environ.get("ENERGEX_READ_API_KEY")
+    if expected and not (x_api_key and hmac.compare_digest(x_api_key, expected)):
+        raise HTTPException(status_code=401, detail="missing or invalid API key")
+
+
 def create_app() -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -124,6 +136,20 @@ def create_app() -> FastAPI:
 
     app = FastAPI(title="energex S2 read API", lifespan=lifespan)
 
+    # CORS is opt-in and origin-scoped: ENERGEX_CORS_ORIGINS is a comma-separated allow-list
+    # (e.g. the frontend origin). Unset = no cross-origin access (the safe default).
+    origins = [
+        o.strip() for o in os.environ.get("ENERGEX_CORS_ORIGINS", "").split(",") if o.strip()
+    ]
+    if origins:
+        app.add_middleware(
+            CORSMiddleware, allow_origins=origins, allow_methods=["GET"], allow_headers=["*"]
+        )
+    if not os.environ.get("ENERGEX_READ_API_KEY"):
+        logger.warning(
+            "read API is UNAUTHENTICATED — set ENERGEX_READ_API_KEY to require an X-API-Key header"
+        )
+
     @app.get("/healthz")
     def healthz() -> dict[str, Any]:
         ac = app.state.arctic
@@ -134,16 +160,16 @@ def create_app() -> FastAPI:
             latest = None
         return {"status": "ok", "libraries": libraries, "latest_as_of": latest}
 
-    @app.get("/libraries")
+    @app.get("/libraries", dependencies=[Depends(_require_api_key)])
     def libraries() -> list[str]:
         return list(app.state.arctic.list_libraries())
 
-    @app.get("/symbols")
+    @app.get("/symbols", dependencies=[Depends(_require_api_key)])
     def symbols(library: str = Query(...)) -> list[str]:
         lib = _get_library(app.state.arctic, library)
         return [s for s in lib.list_symbols() if not s.endswith(VINTAGE_SUFFIX)]
 
-    @app.get("/series")
+    @app.get("/series", dependencies=[Depends(_require_api_key)])
     def series(
         library: str = Query(...),
         symbol: str = Query(...),
@@ -164,14 +190,27 @@ def create_app() -> FastAPI:
         except SymbologyError:
             mode = None  # unknown library -> fall back to symbol-based routing
         df = storage.read_as_of(lib, symbol, as_of=when, date_range=date_range, mode=mode)
+        # Cap an unbounded full-history read so a single request cannot serialize an arbitrarily
+        # large series into one response; intentional bounded reads (start/end) are exempt.
+        max_rows = int(os.environ.get("ENERGEX_SERIES_MAX_ROWS", "500000"))
+        if date_range is None and df is not None and len(df) > max_rows:
+            raise HTTPException(
+                status_code=413,
+                detail=f"series has {len(df)} rows (> {max_rows}); narrow with start/end",
+            )
         return _records(df)
 
-    @app.get("/curve")
+    @app.get("/curve", dependencies=[Depends(_require_api_key)])
     def curve(
         commodity: str = Query(...), as_of: str | None = Query(default=None)
     ) -> list[dict[str, Any]]:
         when = _parse_dt(as_of, "as_of")
-        df = storage.read_curve(commodity, when)
+        try:
+            df = storage.read_curve(commodity, when)
+        except SymbologyError as exc:
+            raise HTTPException(
+                status_code=404, detail=f"unknown commodity: {commodity!r}"
+            ) from exc
         return _records(df)
 
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta, timezone
+import os
+
+# Set BEFORE any energex import: the suite must not load the repo-root .env, so the offline
+# no-credentials invariant holds regardless of a developer's local .env.
+os.environ["ENERGEX_SKIP_DOTENV"] = "1"
+
+from datetime import date, datetime, timedelta, timezone  # noqa: E402
 
 # NOTE: arcticdb MUST be imported before pandas/pyarrow process-wide (phase0 findings:
 # AWS-SDK symbol collision aborts the process on macOS otherwise). conftest loads before

--- a/tests/test_connector_ercot.py
+++ b/tests/test_connector_ercot.py
@@ -15,7 +15,7 @@ from energex.core.connectors.ercot import (
     ErcotRtSppConnector,
     _cpt_hour_ending_to_utc,
 )
-from energex.core.exceptions import ConfigurationError
+from energex.core.exceptions import ConfigurationError, DataFetchError
 
 TOKEN_URL = (
     "https://ercotb2c.b2clogin.com/ercotb2c.onmicrosoft.com/"
@@ -125,12 +125,94 @@ def test_rt_spp_drops_non_hub_loadzone_points():
 
 def test_cpt_hour_ending_to_utc_summer_and_winter():
     days = pd.Series(["2026-06-25", "2026-01-15"])
-    minutes = pd.Series([60, 60])  # hour ending 01:00
+    end_minutes = pd.Series([60, 60])  # hour ending 01:00
     dst = pd.Series([False, False])
-    out = _cpt_hour_ending_to_utc(days, minutes, dst)
+    out = _cpt_hour_ending_to_utc(days, end_minutes, dst, 60)
     # CDT (summer) = UTC-5 -> 06:00Z; CST (winter) = UTC-6 -> 07:00Z.
     assert out.iloc[0] == pd.Timestamp("2026-06-25T06:00:00Z")
     assert out.iloc[1] == pd.Timestamp("2026-01-15T07:00:00Z")
+
+
+def test_cpt_hour_ending_to_utc_fall_back_keeps_both_repeats_distinct():
+    # 2026-11-01 fall-back: the 01:00-02:00 (hour-ending 02:00) hour repeats. ERCOT marks the
+    # daylight repeat DSTFlag=True (CDT, ends 07:00Z) and the standard repeat False (CST, 08:00Z).
+    days = pd.Series(["2026-11-01", "2026-11-01"])
+    end_minutes = pd.Series([120, 120])  # hour ending 02:00
+    dst = pd.Series([True, False])
+    out = _cpt_hour_ending_to_utc(days, end_minutes, dst, 60)
+    assert out.iloc[0] == pd.Timestamp("2026-11-01T07:00:00Z")  # CDT repeat
+    assert out.iloc[1] == pd.Timestamp("2026-11-01T08:00:00Z")  # CST repeat
+    assert out.iloc[0] != out.iloc[1]  # the two settlement hours must not collapse
+
+
+def test_cpt_hour_ending_to_utc_spring_forward():
+    # 2026-03-08 spring-forward: 02:00-03:00 CST is skipped (ERCOT omits hour-ending 03:00).
+    # Hour-ending 02:00 (still CST, ends at the 02:00 instant that jumps to 03:00 CDT) and the
+    # following CDT hours must convert without collapsing onto one instant.
+    days = pd.Series(["2026-03-08", "2026-03-08"])
+    end_minutes = pd.Series([120, 240])  # HE 02:00 (CST) and HE 04:00 (CDT)
+    dst = pd.Series([False, False])
+    out = _cpt_hour_ending_to_utc(days, end_minutes, dst, 60)
+    # HE 02:00: begins 01:00 CST = 07:00Z, +1h = 08:00Z; HE 04:00: begins 03:00 CDT = 08:00Z,
+    # +1h = 09:00Z. Distinct.
+    assert out.iloc[0] == pd.Timestamp("2026-03-08T08:00:00Z")
+    assert out.iloc[1] == pd.Timestamp("2026-03-08T09:00:00Z")
+
+
+@respx.mock
+def test_dam_spp_fall_back_day_preserves_both_repeated_hours():
+    from energex.core.connectors.ercot import ErcotDamSppConnector
+
+    respx.post(TOKEN_URL).mock(return_value=httpx.Response(200, json=_TOKEN))
+    page = _envelope(
+        _DAM_FIELDS,
+        [
+            ["2026-11-01", "02:00", "HB_HOUSTON", 20.0, True],  # CDT repeat
+            ["2026-11-01", "02:00", "HB_HOUSTON", 21.0, False],  # CST repeat
+        ],
+    )
+    respx.get(DAM_URL).mock(return_value=httpx.Response(200, json=page))
+    result = ErcotDamSppConnector(**_kwargs()).fetch(date(2026, 11, 1), date(2026, 11, 1))
+    # Both physically distinct settlement hours survive (the dedup must not collapse them).
+    assert len(result.frame) == 2
+    assert result.frame["valid_time"].nunique() == 2
+    assert set(result.frame["price"]) == {20.0, 21.0}
+
+
+@respx.mock
+def test_token_mint_does_not_retry_on_4xx():
+    # A 401 (bad creds) must fail fast, not hammer the Azure AD B2C auth endpoint with retries.
+    route = respx.post(TOKEN_URL).mock(
+        return_value=httpx.Response(401, json={"error": "invalid_grant"})
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        ErcotRtSppConnector(**_kwargs()).fetch(date.today(), date.today())
+    assert route.call_count == 1  # exactly one attempt, no retries on 4xx
+
+
+@respx.mock
+def test_get_pages_raises_when_data_has_no_fields_schema():
+    respx.post(TOKEN_URL).mock(return_value=httpx.Response(200, json=_TOKEN))
+    bad = {  # data rows but no 'fields' column schema -> would silently vanish
+        "data": [[_TODAY, 1, 1, "HB_HOUSTON", "HU", 30.0, False]],
+        "_meta": {"totalPages": 1, "currentPage": 1},
+    }
+    respx.get(RT_URL).mock(return_value=httpx.Response(200, json=bad))
+    with pytest.raises(DataFetchError, match="fields"):
+        ErcotRtSppConnector(**_kwargs()).fetch(date.today(), date.today())
+
+
+@respx.mock
+def test_get_pages_handles_missing_meta_without_truncation():
+    respx.post(TOKEN_URL).mock(return_value=httpx.Response(200, json=_TOKEN))
+    # No _meta envelope at all: a short page must be returned as-is (not dropped, not looped).
+    page = {
+        "data": [[_TODAY, 1, 1, "HB_HOUSTON", "HU", 30.0, False]],
+        "fields": [{"name": n} for n in _RT_FIELDS],
+    }
+    respx.get(RT_URL).mock(return_value=httpx.Response(200, json=page))
+    result = ErcotRtSppConnector(**_kwargs()).fetch(date.today(), date.today())
+    assert set(result.frame["settlement_point"]) == {"HB_HOUSTON"}
 
 
 def test_rt_spp_fails_fast_without_creds(monkeypatch):

--- a/tests/test_core_config_settings.py
+++ b/tests/test_core_config_settings.py
@@ -48,10 +48,8 @@ def test_config_old_and_new_paths_are_identical():
 
 def test_ercot_subscription_key_reads_primary(monkeypatch):
     monkeypatch.setenv("ERCOT_API_KEY_PRIMARY", "primary-xyz")
-    monkeypatch.setenv("ERCOT_API_KEY_SECONDARY", "secondary-xyz")
     cfg = ConnectorConfig()
     assert cfg.ercot_subscription_key.get_secret_value() == "primary-xyz"
-    assert cfg.ercot_subscription_key_secondary.get_secret_value() == "secondary-xyz"
 
 
 def test_ercot_subscription_key_falls_back_to_legacy_name(monkeypatch):

--- a/tests/test_definitions_load.py
+++ b/tests/test_definitions_load.py
@@ -2,6 +2,8 @@
 
 import subprocess
 import sys
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import dagster as dg
 
@@ -56,3 +58,22 @@ def test_dagster_definitions_validate_cli():
     )
     assert result.returncode == 0, result.stderr
     assert "Validation successful" in (result.stdout + result.stderr)
+
+
+def test_ercot_schedules_target_correct_operating_day():
+    import dagster as dg
+
+    from energex.orchestration.schedules import (
+        ercot_dam_spp_schedule,
+        ercot_load_schedule,
+        ercot_rt_spp_schedule,
+    )
+
+    # 14:00 CPT on operating day D: RT/load capture D (today, intraday); DAM captures D+1
+    # (the next-day curve that cleared midday). A "latest-ended partition" heuristic would
+    # wrongly select D-1 for all three.
+    tick = datetime(2026, 6, 15, 14, 0, tzinfo=ZoneInfo("America/Chicago"))
+    ctx = dg.build_schedule_context(scheduled_execution_time=tick)
+    assert ercot_rt_spp_schedule(ctx).partition_key == "2026-06-15"
+    assert ercot_load_schedule(ctx).partition_key == "2026-06-15"
+    assert ercot_dam_spp_schedule(ctx).partition_key == "2026-06-16"

--- a/tests/test_readapi.py
+++ b/tests/test_readapi.py
@@ -139,3 +139,28 @@ def test_series_bad_as_of_400(client):
 def test_curve(client):
     rows = client.get("/curve", params={"commodity": "crude", "as_of": A2.isoformat()}).json()
     assert {row["instrument_id"] for row in rows} == {"CME.CL.CLF26", "CME.CL.CLG26"}
+
+
+def test_curve_unknown_commodity_404(client):
+    # An unknown commodity must be a clean 4xx, not a 500 from an uncaught SymbologyError.
+    assert client.get("/curve", params={"commodity": "nope"}).status_code == 404
+
+
+def test_series_row_cap_413(client, monkeypatch):
+    monkeypatch.setenv("ENERGEX_SERIES_MAX_ROWS", "1")  # force the cap (fixture has 3 rows)
+    full = client.get("/series", params={"library": "prices.futures", "symbol": "CL_CLF26"})
+    assert full.status_code == 413
+    # an intentionally bounded read (start/end) is exempt from the cap
+    bounded = client.get(
+        "/series",
+        params={"library": "prices.futures", "symbol": "CL_CLF26", "start": D1.isoformat()},
+    )
+    assert bounded.status_code == 200
+
+
+def test_api_key_required_when_configured(client, monkeypatch):
+    monkeypatch.setenv("ENERGEX_READ_API_KEY", "s3cret")
+    assert client.get("/libraries").status_code == 401  # missing key
+    assert client.get("/libraries", headers={"X-API-Key": "wrong"}).status_code == 401
+    assert client.get("/libraries", headers={"X-API-Key": "s3cret"}).status_code == 200
+    assert client.get("/healthz").status_code == 200  # healthz stays open for healthchecks

--- a/tests/test_storage_pointintime.py
+++ b/tests/test_storage_pointintime.py
@@ -13,6 +13,7 @@ D2 = datetime(2024, 1, 8, tzinfo=timezone.utc)
 D3 = datetime(2024, 1, 15, tzinfo=timezone.utc)
 A1 = datetime(2024, 1, 16, 15, 30, tzinfo=timezone.utc)
 A2 = datetime(2024, 1, 23, 15, 30, tzinfo=timezone.utc)
+A3 = datetime(2024, 1, 30, 15, 30, tzinfo=timezone.utc)
 
 
 def _frame(times, values):
@@ -80,3 +81,37 @@ def test_idempotent_recommit_is_a_noop(arctic_lib):
     )
     assert v1 == v2  # same as_of => no new version, original values intact
     assert _close_at(storage.read_as_of(arctic_lib, "CL_CLF26", as_of=A1), D1) == 10.0
+
+
+def test_unchanged_recommit_under_new_as_of_creates_no_new_vintage(arctic_lib):
+    # Re-pulling identical data at a LATER knowledge-time adds no information, so it must not
+    # write a new vintage — otherwise an unchanged hourly ERCOT re-materialization grows the
+    # store without bound. A genuinely changed re-pull still commits.
+    common = {"source": "yf", "source_url": "u", "mode": "bitemporal_merge"}
+    v1 = storage.commit_vintage(
+        arctic_lib,
+        "CL_CLF26",
+        _frame([D1, D2, D3], [10.0, 11.0, 12.0]),
+        as_of=A1,
+        fetched_at=A1,
+        **common,
+    )
+    v2 = storage.commit_vintage(
+        arctic_lib,
+        "CL_CLF26",
+        _frame([D1, D2, D3], [10.0, 11.0, 12.0]),
+        as_of=A2,
+        fetched_at=A2,
+        **common,
+    )
+    assert v2 == v1  # identical payload under a new as_of => no new vintage
+    v3 = storage.commit_vintage(
+        arctic_lib,
+        "CL_CLF26",
+        _frame([D1, D2, D3], [10.0, 11.0, 99.0]),
+        as_of=A3,
+        fetched_at=A3,
+        **common,
+    )
+    assert v3 != v1  # a real revision still creates a vintage
+    assert _close_at(storage.read_as_of(arctic_lib, "CL_CLF26", as_of=A3), D3) == 99.0

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -16,6 +16,24 @@ def test_every_entry_mode_matches_library_class():
         )
 
 
+def test_power_prefix_modes_match_library_class():
+    # The rule-based router (_POWER_PREFIX) must hold the same mode<->library invariant the
+    # static _TABLE guardrail enforces.
+    for prefix, (library, mode) in symbology._POWER_PREFIX.items():
+        assert mode == symbology.LIBRARY_MODE[library], (
+            f"{prefix}: mode {mode!r} != library {library!r} class "
+            f"{symbology.LIBRARY_MODE[library]!r}"
+        )
+
+
+def test_resolve_power_rejects_malformed_ids():
+    # A prefix with no tail, an empty (trailing-dot) tail, or an unknown series must not
+    # resolve to a library — they raise rather than silently mis-route.
+    for bad in ("ERCOT.SPP", "ERCOT.SPP.", "EIA930.D", "EIA930.ZZ.ERCO"):
+        with pytest.raises(SymbologyError):
+            symbology.resolve(bad)
+
+
 def test_resolve_revision_mode_and_symbol_lookups():
     assert symbology.resolve("CME.CL.CLF26") == ("prices.futures", "CL_CLF26")
     assert symbology.revision_mode("CME.CL.CLF26") == "bitemporal_merge"

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -24,7 +24,7 @@ docker compose --profile full up -d
 | `dagster-webserver` | Energex (amd64) | 3000 | Dagster UI |
 | `dagster-daemon` | Energex (amd64) | — | Runs schedules/sensors |
 | `neo4j` | Neo4j 5 Community | 7474, 7687 | Optional entity graph |
-| `energex` | Energex | 8000 | Legacy FastAPI service |
+| `api` | Energex | 8000 | S2 read API (`/series`, `/curve`, `/symbols`, `/libraries`) |
 
 A lighter `dev` profile brings up just MinIO, `minio-init`, and `dagster-postgres` for
 local iteration with `uv run dagster dev`.

--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -34,7 +34,7 @@ The `full` profile starts:
 | `minio` | 9000 / 9001 | ArcticDB object store + web console |
 | `minio-init` | — | One-shot: creates the bucket and scoped service account |
 | `neo4j` | 7474 / 7687 | Optional entity graph |
-| `energex` | 8000 | Legacy FastAPI service |
+| `api` | 8000 | S2 read API (`/series`, `/curve`, `/symbols`, `/libraries`) |
 
 Then open:
 


### PR DESCRIPTION
Resolves all 28 adversarially-verified findings from the codebase audit, in six themed,
test-backed commits. +13 tests; full suite green, ruff + gitleaks clean.

## Critical / High
- **F1/F4 — ERCOT schedules targeted the wrong operating day.** DAM now fetches the NEXT day's
  curve (it clears midday); RT/load capture the CURRENT day intraday. ERCOT_DAILY is keyed by the
  Central operating day (`timezone` + `end_offset=2`). Regression test asserts the 14:00 CPT tick
  on day D selects D+1 (DAM) and D (RT/load).
- **F2/F6 — DST data loss.** The hour-ending instant was localized, so the November fall-back hour
  collapsed (25h→24h) and `drop_duplicates` deleted one. Now the interval *beginning* is localized
  so `DSTFlag` disambiguates; validated against the real 2025-11-02 payload (100 distinct RT
  intervals preserved). Fall-back + spring-forward regression tests added.
- **F3 (+F9/F12) — unbounded vintage growth.** `commit_vintage` now skips a commit whose payload
  matches the latest vintage (ignoring per-commit `as_of`/`fetched_at`), so an unchanged hourly
  re-pull no longer writes a fresh full-history vintage; this also makes the per-symbol commit loop
  idempotent on retry and sharply cuts O(N²) rewrites.
- **F5 — read API auth.** Optional `X-API-Key` gate (`ENERGEX_READ_API_KEY`) on data endpoints;
  `/healthz` stays open; an unauthenticated start logs a warning.

## Medium
F7 raise on data-without-fields · F8 partition-relative freshness (backfills no longer fail the
gate) · F10/F23/F26 deterministic package-relative `.env` load via an explicit opt-out · F11
`/series` row cap (413) · F13 retry only on 5xx/transport (no 4xx auth hammering) · F14 compose
requires `MINIO_ROOT_*`/`ARCTIC_*`/`NEO4J_AUTH` instead of baking weak defaults · F19 microsecond
snapshot names.

## Low
F15 keep paging when `totalPages` absent · F16 coerce bad `hourEnding` · F17 `/curve` 404 (not 500)
· F18 hub/LZ allowlist drift warning · F20 per-symbol staleness surfaced in the read-back check ·
F21 drop dead config field · F22 symbology `_POWER_PREFIX` + malformed-id coverage · F24 relabel
legacy :8000 docs as the S2 read API · F25 `follow_redirects=False` · F27 opt-in scoped CORS · F28
narrow the gitleaks `tests/` allowlist.

## Notes
- **F14 follow-up (operational):** the running stack still uses its current (weak) MinIO/Neo4j
  creds, now provided via `.env`. Rotating `MINIO_ROOT_*`/`NEO4J_AUTH` to strong values, and the
  `ARCTIC_*` keys (which the existing MinIO data is locked to), requires a credential rotation +
  data migration — intentionally not done here.