### PR TITLE
docs: rewrite all docs for the power-markets platform + publish to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "website/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Docusaurus
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/build
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -6,29 +6,29 @@ sidebar_label: Architecture
 
 # Architecture
 
-Energex uses a **hexagonal (ports-and-adapters)** architecture. The domain core is pure
-and framework-agnostic; the orchestration layer is the only place a framework (Dagster)
-is allowed to appear. This keeps the valuable, hard-to-test logic — connectors and the
-bitemporal store — free of framework entanglement, and makes the boundaries explicit
-and enforceable.
+Energex is a **bitemporal, point-in-time data platform for power markets**, built on a
+**hexagonal (ports-and-adapters)** architecture. The domain core is pure and
+framework-agnostic; each outer layer owns exactly one framework. This keeps the valuable,
+hard-to-test logic — the connectors and the bitemporal store — free of framework
+entanglement, and makes the boundaries explicit and enforceable.
 
-## The four layers
+## The layers
 
 | Layer | Package | Responsibility | Status |
 | --- | --- | --- | --- |
-| **Core** (pure) | `energex.core` | Connectors, storage, quality gate, symbology, schemas, config. No framework imports. | Built |
+| **Core** (pure) | `energex.core` | Connectors, bitemporal storage, the pandera quality gate, symbology, schemas, config. No framework imports. | Built |
 | **Orchestration** | `energex.orchestration` | The only Dagster importer: assets, checks, partitions, schedules, resources, reconcile, definitions. | Built |
-| **Serving** | `energex.service` | FastAPI read API, `as_of` first-class. | Reserved (S2) |
-| **Agent** | `energex.agent` | LangGraph analytical agent over the read API. | Reserved (S3) |
+| **Serving (S2)** | `energex.service` | A read-only FastAPI with `as_of` as a first-class parameter. | **Built — live on `:8000`** |
+| **Agent (S3)** | `energex.agent` | A LangGraph analytical agent over the read API. | Reserved |
 
-The **S4 frontend** is a separate private repository — the commercial product. It
-consumes only the S2 read API; neither repo imports the other. That clean seam is the
-open-core boundary (see the [Roadmap](./roadmap.md)).
+The **S4 frontend** is a separate private repository — the commercial product. It consumes
+only the S2 read API; neither repo imports the other. That clean seam is the open-core
+boundary (see the [Roadmap](./roadmap.md)).
 
 ## The core is framework-agnostic, and CI enforces it
 
-`energex.core` must never import an application framework. This is not a guideline; it is
-a test. `tests/test_core_has_no_framework_imports.py` walks every `.py` file under
+`energex.core` must never import an application framework. This is not a guideline; it is a
+test. `tests/test_core_has_no_framework_imports.py` walks every `.py` file under
 `src/energex/core` and fails the build if any of them import `dagster`, `fastapi`, or
 `langgraph`.
 
@@ -39,61 +39,85 @@ FRAMEWORK_IMPORT = re.compile(r"^\s*(?:import|from)\s+(dagster|fastapi|langgraph
 ```
 
 The practical rule: business logic and storage live in the core; framework glue lives in
-the layer that owns the framework. Orchestration imports the core, never the reverse.
+the layer that owns the framework. Orchestration and the read API import the core, never
+the reverse.
 
 ## Data flow
 
 ```
-sources ──> Connector ──> quality gate ──> ArcticDB (MinIO)
-(EIA/NOAA/   (core)        (pandera)        bitemporal store of record
- FRED/yf)                                          │
-                                                   ▼
-                          Dagster (assets · schedules · checks · reconcile)
+power & supporting sources ──> Connector ──> quality gate ──> ArcticDB (MinIO)
+EIA-930 (all BAs) · ERCOT       (core)        (pandera)        bitemporal store of record
+RT/DA SPP + load · FRED ·                                            │
+EIA fundamentals · NOAA                          ┌──────────────────┴───────────────────┐
+                                                 ▼                                       ▼
+                          Dagster (assets · schedules · checks · reconcile)   S2 read API (FastAPI)
+                                                                                         │
+                                                                                         ▼
+                                                                          S4 frontend / S3 agent
 ```
 
-1. A **connector** (`energex.core.connectors`) fetches a window from a source and returns
-   a `FetchResult` — a dataframe with `instrument_id`, a tz-aware UTC `valid_time`, value
-   columns, and provenance (`source`, `fetched_at`, `source_url`).
-2. The **quality gate** (`energex.core.quality`, pandera schemas) validates the frame
-   *before* any write. The same `validate(...)` call runs in the asset and is re-run by
-   the asset check — a single source of truth.
+1. A **connector** (`energex.core.connectors`) fetches a window from a source and returns a
+   `FetchResult` — a dataframe with `instrument_id`, a tz-aware UTC `valid_time`, value
+   columns, and provenance (`source`, `fetched_at`, `source_url`, `complete_over_range`).
+   The live connectors are EIA-930 (region + by-fuel, all balancing authorities), ERCOT
+   (real-time + day-ahead SPP and system load), and the supporting FRED / EIA-fundamentals /
+   NOAA feeds. See [Data Sources & Connectors](./data-sources-connectors.md).
+2. The **quality gate** (`energex.core.quality`, pandera schemas in `energex.core.schemas`)
+   validates the frame *before* any write — dtypes, value bands, `(instrument_id,
+   valid_time)` uniqueness, a row-count floor, and a release-calendar-aware freshness bound.
+   The same `validate(...)` call runs in the asset and is re-run by the asset check, so the
+   gate is a single source of truth.
 3. The **storage layer** (`energex.core.storage`) commits to ArcticDB according to the
-   instrument's revision mode.
-4. **Dagster** ties it together: one asset per source, scheduled releases, asset checks,
-   and an orphan-reconcile asset.
+   instrument's revision mode, recording each vintage in a per-symbol `__vintages` index.
+4. **Dagster** ties it together: one asset per series, scheduled releases, a read-back asset
+   check per asset, and an orphan-reconcile asset.
+5. The **S2 read API** (`energex.service.readapi`) serves the store point-in-time over HTTP —
+   the only contract the frontend consumes. See
+   [Frontend Integration](./frontend-integration.md).
+
+## Symbology — the single router
+
+`energex.core.symbology` maps an `instrument_id` to its `(library, symbol, revision_mode)`.
+A static table covers the low-cardinality series; a rule-based `power.*` tail routes the
+high-cardinality power namespace (e.g. `EIA930.D.<BA>` → `power.demand`, `ERCOT.SPP.<sp>` →
+`power.lmp`) without enumerating the ~65–73 balancing authorities or every settlement point.
+Mode is a property of the library, so bare power symbols never need to appear in a static
+index.
 
 ## The bitemporal model
 
 Every observation carries two time axes:
 
-- **`valid_time`** — the period the row describes.
-- **`as_of`** — the knowledge/release time, i.e. when Energex learned the value.
+- **`valid_time`** — the period the row describes (e.g. the hour ending `2026-06-26T10:00Z`).
+- **`as_of`** — the knowledge time: when Energex learned the value.
 
-Reads are addressed by knowledge time. `read_as_of(symbol, as_of=T)` resolves the
-version that was current at `T` and returns it — never leaking anything learned after
-`T`. With `as_of` omitted, it returns the latest committed vintage.
+Reads are addressed by knowledge time. `read_as_of(lib, symbol, as_of=T)` resolves the
+version that was current at `T` and returns it — never leaking anything learned after `T`.
+With `as_of` omitted it returns the latest committed vintage.
 
 ### Revision modes
 
-Each instrument is routed by `energex.core.symbology` to exactly one revision mode, which
-determines how a new release is committed:
+Each instrument is routed by symbology to exactly one revision mode, which determines how a
+new release is committed:
 
 | Mode | Meaning | Used by |
 | --- | --- | --- |
-| `degenerate` | Never-revised stream. Append-with-dedup; `as_of` = `fetched_at`. No vintage index. | FRED spot, intraday bars |
+| `degenerate` | Final, never-revised stream. Append-with-dedup; `as_of` = `fetched_at`. No vintage index. | EIA-930 (demand / forecast / generation / interchange / by-fuel), FRED spot, intraday bars |
+| `bitemporal_merge` | Each release may revise a window *inline*. Read-modify-write merges the revision onto the prior as-known series, by exact `valid_time`. | ERCOT RT/DA SPP + load, EIA weekly fundamentals |
 | `bitemporal_replace` | Each release is a *complete* as-known series. Full versioned write per `as_of`. | NOAA degree days |
-| `bitemporal_merge` | Each release revises a window *inline*. Read-modify-write merges the revision onto the prior as-known series, by exact `valid_time`. | EIA fundamentals |
+
+`commit_vintage` is **content-idempotent**: a re-pull whose payload matches the latest
+committed vintage writes no new vintage, so an unchanged hourly ERCOT re-materialization does
+not grow the store.
 
 ### The honesty flag
 
-True point-in-time history accrues only going forward, because EIA/ERCOT revise inline
-with no vintage parameter. History captured later by backfilling is a snapshot of
-already-revised data. Energex stamps those rows `vintage_reconstructed=True` so backtests
-never treat a reconstructed baseline as something that was actually observed at the time.
-
-The orchestration layer decides the flag from the partition's age: a NOAA or EIA
-partition whose period closed longer ago than a grace window is a backfill of today's
-already-revised file, so it is committed with `reconstructed=True`.
+True point-in-time history accrues only going forward, because EIA/ERCOT revise inline with
+no vintage parameter. History captured later by backfilling is a snapshot of already-revised
+data. Energex stamps those rows `vintage_reconstructed=True` so backtests never treat a
+reconstructed baseline as something that was actually observed at the time. The orchestration
+layer decides the flag from the partition's age: a partition whose period closed longer ago
+than a grace window is a backfill of an already-revised release.
 
 See [Storage & Point-in-Time](./storage-point-in-time.md) for the commit protocol, the
 per-symbol version index, and crash safety.

--- a/website/docs/data-sources-connectors.md
+++ b/website/docs/data-sources-connectors.md
@@ -8,27 +8,78 @@ sidebar_label: Data Sources & Connectors
 
 Energex is focused on **power markets**, with weather and gas/oil fundamentals as
 supporting context. Each source is ingested through a dedicated connector in
-`energex.core.connectors`. A connector is responsible for one thing: pull a window from a
-source and return a normalized `FetchResult`. It knows nothing about storage or Dagster.
+`energex.core.connectors`. A connector does exactly one thing: pull a window from a source
+and return a normalized `FetchResult`. It knows nothing about storage, the quality gate, or
+Dagster — that wiring lives in [Orchestration](./orchestration.md). The connector layer is
+framework- **and** storage-agnostic and must never import `arcticdb`.
 
 ## Power sources
+
+These are the primary feeds. EIA-930 is the always-on backbone (every US balancing
+authority); ERCOT adds nodal Texas price and load detail.
 
 | Source | Connector class | ArcticDB library | Cadence | Revision mode |
 | --- | --- | --- | --- | --- |
 | **EIA-930** — hourly demand / day-ahead forecast / net generation / interchange (all BAs) | `Eia930RegionConnector` | `power.demand`, `power.demand_forecast`, `power.generation`, `power.interchange` | Hourly | `degenerate` |
 | **EIA-930** — hourly net generation by fuel type (all BAs) | `Eia930FuelConnector` | `power.generation_by_fuel` | Hourly | `degenerate` |
-| **ERCOT** — real-time (15-min) settlement point prices, hubs + load zones | `ErcotRtSppConnector` | `power.lmp` | 15-min (hourly refresh) | `bitemporal_merge` |
-| **ERCOT** — day-ahead-market hourly settlement point prices | `ErcotDamSppConnector` | `power.dalmp` | Daily | `bitemporal_merge` |
-| **ERCOT** — ERCOT-wide actual system load | `ErcotLoadConnector` | `power.load` | Hourly | `bitemporal_merge` |
+| **ERCOT** — real-time (15-min) settlement-point prices, hubs + load zones | `ErcotRtSppConnector` | `power.lmp` | Intraday (hourly capture) | `bitemporal_merge` |
+| **ERCOT** — day-ahead-market hourly settlement-point prices | `ErcotDamSppConnector` | `power.dalmp` | Daily (next-day curve) | `bitemporal_merge` |
+| **ERCOT** — ERCOT-wide actual system load | `ErcotLoadConnector` | `power.load` | Intraday (hourly capture) | `bitemporal_merge` |
 
-ERCOT authenticates via Azure AD B2C ROPC (`ERCOT_USERNAME` / `ERCOT_PASSWORD` plus an APIM
-subscription key in `ERCOT_API_KEY_PRIMARY`) and serves nodal reports under
-`api.ercot.com/api/public-reports`. The connectors mint an ID token, page through the
-`data` / `fields` / `_meta` envelope, and convert Central Prevailing time to UTC. Only the
-canonical tradeable settlement points (5 trading hubs + 8 load zones) are ingested. Fuel
-mix is **not** on the public-reports API — ERCOT fuel mix is served by EIA-930
-(`EIA930.GEN_FUEL.ERCO`). Absent credentials, the connectors fail fast with a clear message.
-EIA-930 needs only the existing `EIA_API_KEY`.
+EIA-930 needs only the existing `EIA_API_KEY`. ERCOT authenticates via Azure AD B2C ROPC
+(`ERCOT_USERNAME` / `ERCOT_PASSWORD` plus an APIM subscription key in
+`ERCOT_API_KEY_PRIMARY`); absent credentials the ERCOT connectors fail fast with a clear
+`ConfigurationError`.
+
+### EIA-930 hourly grid monitor
+
+The EIA-930 Hourly Electric Grid Monitor is the core power feed, served by two EIA v2 routes
+for **every US balancing authority** (~65–73 BAs — the `respondent` facet is omitted, so all
+BAs come back):
+
+- `electricity/rto/region-data` — demand (`D`), day-ahead forecast (`DF`), net generation
+  (`NG`), and total interchange (`TI`) → instruments `EIA930.{D,DF,NG,TI}.<BA>`, routed to
+  `power.demand` / `power.demand_forecast` / `power.generation` / `power.interchange` by
+  `Eia930RegionConnector`.
+- `electricity/rto/fuel-type-data` — net generation by fuel type →
+  `EIA930.GEN_FUEL.<BA>` (carrying a `fuel_type` column), routed to
+  `power.generation_by_fuel` by `Eia930FuelConnector`.
+
+The symbol is the BA code, lowercased (e.g. `erco`, `ciso`). EIA revises these hourly series
+inline, so the assets write `degenerate` (append-with-dedup, latest-wins): a re-pull of a
+recent window simply overwrites changed values. `valid_time` is the hourly `period` at UTC;
+`value` is the MWh reading (signed for interchange, null where EIA has a gap).
+`complete_over_range` is `False`. The `api_key` is read from `core.config`, never hardcoded,
+and the provenance URL redacts it.
+
+Because ERCOT fuel mix is **not** on ERCOT's public API, ERCOT fuel mix is covered here by
+`EIA930.GEN_FUEL.ERCO`.
+
+### ERCOT settlement-point prices and load
+
+ERCOT's public API authenticates via Azure AD B2C ROPC (username + password + a fixed public
+`client_id`) to mint an ID token, then serves report endpoints under
+`https://api.ercot.com/api/public-reports` gated by the APIM subscription key. Responses use
+an array-of-arrays `data` body with a separate `fields` schema and a `_meta` pagination
+envelope. All ERCOT timestamps are Central Prevailing Time (`America/Chicago`), hour-ending,
+and are converted to tz-aware UTC — DST-correct, including the repeated fall-back hour. Three
+connectors are wired:
+
+- **`ErcotRtSppConnector`** — real-time 15-min settlement-point prices (report
+  `np6-905-cd/spp_node_zone_hub`) → `ERCOT.SPP.<sp>` → `power.lmp`.
+- **`ErcotDamSppConnector`** — day-ahead-market hourly settlement-point prices (report
+  `np4-190-cd/dam_stlmnt_pnt_prices`) → `ERCOT.DASPP.<sp>` → `power.dalmp`.
+- **`ErcotLoadConnector`** — ERCOT-wide actual system load (report
+  `np6-345-cd/act_sys_load_by_wzn`, the `total` column) → the single instrument
+  `ERCOT.LOAD.ERCOT` → `power.load`.
+
+Only the **13 canonical tradeable settlement points** are ingested — the 5 trading hubs
+(`HB_HOUSTON`, `HB_NORTH`, `HB_PAN`, `HB_SOUTH`, `HB_WEST`) and 8 load zones (`LZ_AEN`,
+`LZ_CPS`, `LZ_HOUSTON`, `LZ_LCRA`, `LZ_NORTH`, `LZ_RAYBN`, `LZ_SOUTH`, `LZ_WEST`); resource
+nodes are dropped. RT/DAM prices and system load can be restated, so all three assets commit
+`bitemporal_merge`. The connectors page through the envelope and follow no redirects, so a
+30x can never move the credentialed request off-host. Each fetch returns
+`complete_over_range=False` (a window, not the full as-known series).
 
 ## Supporting sources (deprioritized)
 
@@ -36,82 +87,63 @@ Oil & gas and weather remain ingested but are no longer the focus:
 
 | Source | Connector class | ArcticDB library | Cadence | Revision mode |
 | --- | --- | --- | --- | --- |
-| **NOAA nClimDiv** — HDD/CDD by region | `NOAANClimDivConnector` | `weather` | Monthly | `bitemporal_replace` |
 | **FRED** — WTI / Brent / Henry Hub spot | `FredConnector` | `prices.spot` | Daily (weekdays) | `degenerate` |
 | **EIA v2** — Lower-48 working gas in storage | `EiaGasStorageConnector` | `fundamentals.eia` | Weekly (Thu) | `bitemporal_merge` |
 | **EIA v2** — U.S. crude stocks ex-SPR | `EiaPetroleumStatusConnector` | `fundamentals.eia` | Weekly (Wed) | `bitemporal_merge` |
+| **NOAA nClimDiv** — HDD/CDD by region | `NOAANClimDivConnector` | `weather` | Monthly | `bitemporal_replace` |
 | **yfinance** — front-month CL/BZ/NG intraday | `YFinanceIntradayConnector` | `prices.intraday` | Manual (dev only) | `degenerate` |
-
-### EIA-930 hourly grid monitor
-
-EIA's Hourly Electric Grid Monitor (the EIA-930 dataset) is the core power feed, served by
-two EIA v2 routes for **every US balancing authority** (~60–70 BAs):
-
-- `electricity/rto/region-data` — demand (`D`), day-ahead forecast (`DF`), net generation
-  (`NG`), and total interchange (`TI`) → instruments `EIA930.{D,DF,NG,TI}.<BA>`.
-- `electricity/rto/fuel-type-data` — net generation by fuel type →
-  `EIA930.GEN_FUEL.<BA>` (carrying a `fuel_type` column).
-
-Each series is its own library; the symbol is the BA code (e.g. `erco`, `ciso`). The data
-is hourly and finalizes within about a day, so the asset writes `degenerate`
-(append-with-dedup, latest-wins) over a short re-pull window. A `~3-year` backfill seeds
-history; an hourly schedule keeps it current.
-
-### ERCOT nodal
-
-ERCOT's public API covers real-time (NP6-905-CD, 15-min SCED) and day-ahead (NP4-190-CD,
-hourly) settlement point prices → `power.lmp` / `power.dalmp`, and actual system load
-(NP6-345-CD) → `power.load` (one symbol per settlement point; load uses the single
-`ercot` symbol). Prices and load can be restated, so the assets commit `bitemporal_merge`.
-The connectors are unit-tested offline against the real response envelope and run live once
-the ERCOT credentials are present.
-
-### EIA fundamentals
-
-EIA's open-data v2 API serves weekly fundamentals. Two routes are wired, with series
-codes pulled live from EIA's facet endpoints (never invented):
-
-- `natural-gas/stor/wkly` — Lower-48 working gas in underground storage (Bcf) →
-  instrument `EIA.NG.STORAGE.LOWER48`.
-- `petroleum/stoc/wstk` — U.S. crude oil ending stocks **excluding SPR** (thousand
-  barrels) → instrument `EIA.PET.CRUDE.STOCKS`.
-
-EIA has **no vintage parameter** and revises prior weeks **inline**. So every fetch
-widens its window back by a revision lookback (at least five weeks) to re-carry EIA's
-revisions, and the asset commits `bitemporal_merge`. `complete_over_range` is `False` — a
-revision window is not the full as-known series.
-
-### NOAA degree days
-
-NOAA's nClimDiv monthly files provide combined HDD+CDD per region: the contiguous-US
-national aggregate, the nine NCEI climate regions, and Texas. The whole file is reissued
-each month, so each release is a complete as-known series and the asset commits
-`bitemporal_replace`. The flat files are public and need no token.
 
 ### FRED benchmark spot
 
 The St. Louis Fed FRED API serves daily benchmark spot prices with a few-business-day
-publication lag. Three series are pulled:
+publication lag. Three series are pulled (codes verified live, never invented):
 
 - `DCOILWTICO` — WTI crude, Cushing OK ($/bbl) → `FRED.WTI.SPOT`
 - `DCOILBRENTEU` — Brent crude, Europe ($/bbl) → `FRED.BRENT.SPOT`
 - `DHHNGSP` — Henry Hub natural gas ($/MMBtu) → `FRED.HENRYHUB.SPOT`
 
-These are final daily values (FRED does not vintage them on this endpoint), so the stream
-is `degenerate`: the asset appends with de-duplication and `as_of` = `fetched_at`. FRED
-emits missing observations (holidays/gaps) as the string `"."`; those are dropped.
+These are final daily values (FRED does not vintage them on this endpoint), so the stream is
+`degenerate`: the asset appends with de-duplication and `as_of` = `fetched_at`. FRED emits
+missing observations (holidays/gaps) as the string `"."`; those are dropped.
+`complete_over_range` is `False`.
+
+### EIA fundamentals
+
+EIA's open-data v2 API serves weekly fundamentals. Two routes are wired, with series codes
+pulled live from EIA's facet endpoints (never invented):
+
+- `natural-gas/stor/wkly` — Lower-48 working gas in underground storage (Bcf;
+  facets `duoarea=R48`, `process=SWO`, `product=EPG0`) → instrument
+  `EIA.NG.STORAGE.LOWER48`.
+- `petroleum/stoc/wstk` — U.S. crude oil ending stocks **excluding SPR** (thousand barrels;
+  facets `product=EPC0`, `process=SAX`, `duoarea=NUS`) → instrument `EIA.PET.CRUDE.STOCKS`.
+
+EIA has **no vintage parameter** and revises prior weeks **inline**. So every fetch widens
+its window back by a revision lookback (`REVISION_LOOKBACK`, six weeks) to re-carry EIA's
+revisions, and the asset commits `bitemporal_merge`. `complete_over_range` is `False` — a
+revision window is not the full as-known series.
+
+### NOAA degree days
+
+NOAA's nClimDiv monthly fixed-width files (no API token needed) provide combined HDD+CDD per
+region. The connector reads the live directory listing and selects the newest dated
+`climdiv-hddcst-*` / `climdiv-cddcst-*` file (never a hardcoded version), then emits one
+`NOAA.HDD.<region>` instrument per region carrying both `hdd` and `cdd` columns. Coverage is
+the contiguous-US national aggregate (`CONUS`), the nine NCEI climate regions, and Texas. The
+whole file is the full as-known series, so `complete_over_range=True` and the asset commits
+`bitemporal_replace`.
 
 ### yfinance intraday (dev only)
 
-The yfinance connector fetches front-month CL/BZ/NG 1-minute OHLCV bars. It is the S1
-proof-of-pipeline vertical slice and is **not scheduled**: Yahoo frequently blocks
-programmatic access, so a schedule would only fire failing runs. Run it manually from the
-Dagster UI when you want intraday data in dev.
+The yfinance connector fetches front-month CL/BZ/NG 1-minute OHLCV bars
+(`CME.{CL,BZ,NG}.FRONT` → `prices.intraday`). It is the original proof-of-pipeline vertical
+slice and is **not scheduled**: Yahoo frequently blocks programmatic access, so a schedule
+would only fire failing runs. Run it manually from the Dagster UI when you want intraday data
+in dev.
 
 ## The Connector protocol
 
-Every connector implements one small contract from
-`energex.core.connectors.base`:
+Every connector implements one small contract from `energex.core.connectors.base`:
 
 ```python
 @dataclass(frozen=True)
@@ -120,7 +152,7 @@ class FetchResult:
     source: str
     fetched_at: datetime         # tz-aware UTC knowledge time
     source_url: str
-    complete_over_range: bool     # True iff frame is the full as-known series for its span
+    complete_over_range: bool    # True iff frame is the full as-known series for its span
 
 
 @runtime_checkable
@@ -129,53 +161,55 @@ class Connector(Protocol):
     def fetch(self, window_start: date, window_end: date) -> FetchResult: ...
 ```
 
-`complete_over_range` is the merge-vs-replace signal: it is `True` only when the frame is
-the full as-known series for its `valid_time` span (a whole-file replace source), and
-`False` for an inline-revision window or a continuous degenerate stream.
-
-This module is framework- **and** storage-agnostic — it must not import `arcticdb`.
+`complete_over_range` is the merge-vs-replace signal: it is `True` only when the frame is the
+full as-known series for its `valid_time` span (a whole-file replace source like NOAA), and
+`False` for an inline-revision window (EIA fundamentals, ERCOT) or a continuous degenerate
+stream (EIA-930, FRED).
 
 ## How to add a new connector
 
-1. **Pick the instrument IDs and route them.** Add entries to the `_TABLE` in
-   `energex.core.symbology`, mapping each `instrument_id` to its `(library, symbol,
-   revision_mode)`. The revision mode must be consistent with the library's mode in
-   `LIBRARY_MODE`.
+1. **Pick the instrument IDs and route them.** For a fixed, small set of series, add entries
+   to the `_TABLE` in `energex.core.symbology`, mapping each `instrument_id` to its
+   `(library, symbol, revision_mode)`. The revision mode must be consistent with the
+   library's mode in `LIBRARY_MODE`.
 
    ```python
    # energex/core/symbology.py
    "EIA.NG.STORAGE.LOWER48": ("fundamentals.eia", "ng_storage_lower48", "bitemporal_merge"),
    ```
 
-   For high-cardinality namespaces (e.g. the ~60–70 EIA-930 balancing authorities)
-   enumerating every symbol is brittle. Instead add a prefix to `_POWER_PREFIX` and let
-   `resolve()` route by rule (`EIA930.<SERIES>.<BA>` → library + lowercased BA symbol).
-   Because the bare symbol then drops its routing prefix, storage takes the mode
-   explicitly via `mode_for_library()` rather than the symbol-based reverse lookup.
+   For high-cardinality namespaces (e.g. the ~65–73 EIA-930 balancing authorities, or the
+   ERCOT settlement points) enumerating every symbol is brittle. Instead add a prefix to
+   `_POWER_PREFIX` and let `resolve()` route by rule (`EIA930.<SERIES>.<BA>` →
+   library + lowercased BA symbol). Because the bare symbol then drops its routing prefix,
+   storage takes the mode explicitly via `mode_for_library()` rather than the symbol-based
+   reverse lookup.
 
-2. **Define a pandera schema** for the connector's output frame in
-   `energex.core.schemas` (column names, dtypes, nullability, ranges). The quality gate
-   validates against this before any write.
+2. **Define a pandera schema** for the connector's output frame in `energex.core.schemas`
+   (column names, dtypes, nullability, value bands, uniqueness, a row-count floor, and a
+   release-calendar-aware freshness bound). The quality gate (`core.quality.validate`)
+   validates against this before any write and raises `QualityGateError` on failure.
 
 3. **Implement the connector** in `energex/core/connectors/`. Follow the existing ones
    (`fred.py` is the simplest): fetch over the requested window, normalize to columns
    `instrument_id`, tz-aware-UTC `valid_time`, and your value column(s), and return a
    `FetchResult` with accurate provenance and `complete_over_range`. Read API keys from
-   `energex.core.config` (never hardcode), and wrap network calls in tenacity retries
-   over `httpx`. **Do not import a framework.**
+   `energex.core.config` (never hardcode; redact them from `source_url`), and wrap network
+   calls in tenacity retries over `httpx`. **Do not import a framework or `arcticdb`.**
 
 4. **Wire a Dagster asset** in `energex.orchestration.assets`: fetch → `quality.validate`
-   → `storage.write_bars` (degenerate) or `storage.commit_vintage` (bitemporal),
-   grouping the frame by `instrument_id` and resolving each via `symbology.resolve`. Add
-   an asset check in `checks.py` that re-runs the same `validate(...)`.
+   → `storage.write_bars` (degenerate) or `storage.commit_vintage` (bitemporal), grouping
+   the frame by `instrument_id` and resolving each via `symbology.resolve`. Add an asset
+   check in `checks.py` that re-runs the same `validate(...)` against the read-back.
 
-5. **Add a partition + schedule** in `partitions.py` and `schedules.py` if the source has
-   a regular release cadence.
+5. **Add a partition + schedule** in `partitions.py` and `schedules.py` if the source has a
+   regular release cadence.
 
-6. **Test it.** Add a connector test (see `tests/test_connector_*.py`) that mocks the
-   HTTP layer with `respx` and asserts the shape, provenance, and `complete_over_range`
-   of the `FetchResult`.
+6. **Test it.** Add a connector test (see `tests/test_connector_*.py`) that mocks the HTTP
+   layer with `respx` and asserts the shape, provenance, and `complete_over_range` of the
+   `FetchResult`.
 
-See [Orchestration](./orchestration.md) for how assets, checks, and schedules fit
-together, and [Storage & Point-in-Time](./storage-point-in-time.md) for the commit
-functions.
+See [Orchestration](./orchestration.md) for how assets, checks, and schedules fit together,
+and [Storage & Point-in-Time](./storage-point-in-time.md) for the commit functions and the
+bitemporal model. The downstream contract for reading any of this back is the
+[S2 read API](./frontend-integration.md).

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -6,9 +6,10 @@ sidebar_label: Deployment
 
 # Deployment
 
-Energex is designed to run **always-on** on a single host — a Mac Studio on OrbStack is
-the reference target, but any Docker host works. Everything is defined in
-`docker-compose.yml`.
+Energex runs **always-on** on a single host. A Mac Studio on OrbStack is the reference
+target, but any Docker host works. The whole platform — power-market ingestion, the
+bitemporal ArcticDB store, the Dagster orchestrator, and the S2 read API — is defined in
+`docker-compose.yml` and configured from a single `.env`.
 
 ## The full stack
 
@@ -18,74 +19,130 @@ docker compose --profile full up -d
 
 | Service | Image | Ports | Role |
 | --- | --- | --- | --- |
-| `minio` | MinIO | 9000, 9001 | ArcticDB object store + console |
-| `minio-init` | MinIO `mc` | — | One-shot: create bucket + scoped service account |
-| `dagster-postgres` | Postgres 16 | — | Dagster instance storage |
-| `dagster-webserver` | Energex (amd64) | 3000 | Dagster UI |
-| `dagster-daemon` | Energex (amd64) | — | Runs schedules/sensors |
-| `neo4j` | Neo4j 5 Community | 7474, 7687 | Optional entity graph |
-| `api` | Energex | 8000 | S2 read API (`/series`, `/curve`, `/symbols`, `/libraries`) |
+| `minio` | `quay.io/minio/minio` | 9000, 9001 | ArcticDB object store (S3 API) + web console |
+| `minio-init` | `quay.io/minio/mc` | — | One-shot: create the `arctic` bucket + a scoped `arctic-rw` service account |
+| `dagster-postgres` | `postgres:16.4` | — | Dagster run / event / schedule storage |
+| `dagster-webserver` | `ghcr.io/oldhero5/energex:dagster` | 3000 | Dagster UI |
+| `dagster-daemon` | `ghcr.io/oldhero5/energex:dagster` | — | Runs the schedules that ingest every series |
+| `api` | `ghcr.io/oldhero5/energex:api` | 8000 | **S2 read API** — `/series`, `/curve`, `/symbols`, `/libraries`, `/healthz` |
+| `neo4j` | `neo4j:5.26.0-community` | 7474, 7687 | Optional entity graph (reserved) |
 
-A lighter `dev` profile brings up just MinIO, `minio-init`, and `dagster-postgres` for
-local iteration with `uv run dagster dev`.
+The `api` service is the only contract the separate, private frontend consumes — see
+[Frontend integration](./frontend-integration.md). It publishes host port **8000**
+(mapped to the container's `8001`) and serves `energex.service.readapi:app` under uvicorn.
 
-All services set `restart: unless-stopped`, so they recover on crash and when the host
-(or OrbStack) restarts. Logs use the `json-file` driver with rotation (10 MB per file,
-5 files).
+A lighter **`dev`** profile brings up just `minio`, `minio-init`, and `dagster-postgres`,
+which is everything `uv run dagster dev` needs to drive [orchestration](./orchestration.md)
+from your shell while the bitemporal [store](./storage-point-in-time.md) lives in MinIO.
+
+```bash
+docker compose --profile dev up -d
+uv run dagster dev
+```
+
+There is also a `frontend` profile that wires in the private `./frontend` repo (gitignored
+here, so the service is inert until that repo is present) and pulls up the `api` plus the
+MinIO chain it depends on.
+
+## Built images
+
+Both application images build from this repo's `Dockerfile`, differing only in installed
+extras:
+
+- **`ghcr.io/oldhero5/energex:dagster`** — built with `--extra orchestration --extra
+  storage --extra quality --extra graph`; shared by `dagster-webserver` and
+  `dagster-daemon`.
+- **`ghcr.io/oldhero5/energex:api`** — built with `--extra service --extra storage`.
+
+Both run as **`linux/amd64`**. ArcticDB ships no `linux/arm64` wheel, so on M-series Macs
+these images execute under emulation — it works, with somewhat slower cold starts. MinIO,
+Postgres, and Neo4j run natively.
+
+## Restart policy & logging
+
+Every long-running service sets `restart: unless-stopped`, so the stack recovers on crash
+and after a host (or OrbStack) restart. `minio-init` is the exception — it is a one-shot
+provisioner with `restart: "no"` (a restart policy would loop it forever). All services
+log via the `json-file` driver with rotation (10 MB per file, 5 files), and each carries a
+healthcheck plus `mem_limit` / `cpus` caps.
 
 ## Persistence
 
-State lives in named Docker volumes (only `docker compose down -v` deletes them):
+State lives in named Docker volumes — only `docker compose down -v` deletes them:
 
 | Volume | Holds |
 | --- | --- |
 | `minio-data` | The ArcticDB **store of record** |
-| `dagster-pg-data` | Dagster run/event/schedule history |
-| `dagster-home` | Dagster instance config + compute logs |
+| `dagster-pg-data` | Dagster run / event / schedule history |
+| `dagster-home` | Shared `DAGSTER_HOME` (instance config + compute logs) |
 | `neo4j-data` | The entity graph |
 
-## Secrets
+## Configuration: required secrets
 
-Credentials are provided to containers via `env_file: .env` at **runtime** — they are
-never baked into the image, and `.env` is dockerignored. `minio-init` uses the MinIO root
-account to create a **scoped** `arctic-rw` service account (from
-`deploy/minio/arctic-rw.json`); the Dagster containers authenticate with that scoped
-account, not root. Never commit a real `.env`.
+Credentials reach the containers via `env_file: .env` and compose `${VAR}` interpolation
+at **runtime** — they are never baked into an image, and `.env` is dockerignored. Copy
+[`.env.example`](https://github.com/oldhero5/energex/blob/main/.env.example) to `.env` and
+fill in real values; the app-side binding lives in `src/energex/core/config.py`.
 
-## Apple Silicon: the amd64 note
+**`docker-compose.yml` ships no weak built-in defaults for the security-critical secrets.**
+These five use the `${VAR:?…}` form, so compose **refuses to start** until each is set in
+`.env`:
 
-ArcticDB ships no `linux/arm64` wheel. The Dagster webserver and daemon images are
-therefore built and run as **`linux/amd64`** and execute under emulation on M-series
-Macs. It works; expect somewhat slower cold starts. The other services run natively.
+| Variable | Used by | Purpose |
+| --- | --- | --- |
+| `MINIO_ROOT_USER` | `minio`, `minio-init` | MinIO root account |
+| `MINIO_ROOT_PASSWORD` | `minio`, `minio-init` | MinIO root password |
+| `ARCTIC_ACCESS_KEY` | `minio-init`, `api`, dagster | Scoped `arctic-rw` service-account key the app authenticates with (mapped into `MINIO_ACCESS_KEY`) |
+| `ARCTIC_SECRET_KEY` | `minio-init`, `api`, dagster | Scoped service-account secret (mapped into `MINIO_SECRET_KEY`) |
+| `NEO4J_AUTH` | `neo4j` | Neo4j container auth, in `user/password` form |
+
+`minio-init` uses the MinIO **root** account once to create the bucket and a **scoped**
+`arctic-rw` service account from `deploy/minio/arctic-rw.json`. The `api` and Dagster
+containers then authenticate with that scoped account (passed through as
+`MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`) — never with root. Never commit a real `.env`.
+
+The remaining compose variables fall back to safe non-secret defaults if unset:
+`ARCTIC_BUCKET` (`arctic`) and the Dagster Postgres trio `DAGSTER_PG_USERNAME` /
+`DAGSTER_PG_PASSWORD` / `DAGSTER_PG_DB`.
+
+## Configuration: connector API keys
+
+The Dagster containers load `.env` so the connectors can authenticate against each source.
+See [Data sources & connectors](./data-sources-connectors.md) for what each one ingests.
+
+| Variable | Source | Needed for |
+| --- | --- | --- |
+| `EIA_API_KEY` | EIA v2 open-data (free) | EIA-930 power series (the primary feed) + EIA fundamentals |
+| `ERCOT_USERNAME`, `ERCOT_PASSWORD`, `ERCOT_API_KEY_PRIMARY` | ERCOT public API | ERCOT RT/DA SPP + system load (Azure AD B2C ROPC + APIM subscription key) |
+| `FRED_API_KEY` | FRED (St. Louis Fed, free) | WTI / Brent / Henry Hub spot (supporting) |
+| `NOAA_TOKEN` | NOAA CDO (optional) | Reserved; the nClimDiv degree-day connector reads public flat files and needs no token |
+
+## S2 read API configuration
+
+The `api` service reads a few optional `ENERGEX_*` variables (all unset by default — see
+[`.env.example`](https://github.com/oldhero5/energex/blob/main/.env.example)):
+
+- `ENERGEX_READ_API_KEY` — when set, every data endpoint requires a matching `X-API-Key`
+  header; `/healthz` stays open. Unset runs the API open with a startup warning.
+- `ENERGEX_CORS_ORIGINS` — comma-separated allow-list (e.g. the frontend origin); unset
+  means no cross-origin access.
+- `ENERGEX_SERIES_MAX_ROWS` — row cap before an unbounded `/series` read returns `413`
+  (narrow the read with `start` / `end` instead).
+
+## In-network addressing
+
+Containers reach MinIO by the compose **service name** (`MINIO_ENDPOINT=minio:9000`), not
+`localhost`. The Dagster instance config and workspace are mounted read-only from
+`deploy/dagster/dagster.yaml` and `deploy/dagster/workspace.yaml`.
 
 ## OrbStack / 24-7 notes
 
 - Enable OrbStack's **"Start at login"** so the stack comes back after a reboot.
-- Prevent the Mac from sleeping for true 24/7 operation (`caffeinate`, or keep it
-  plugged in with sleep disabled).
+- Prevent the Mac from sleeping for true 24/7 operation (`caffeinate`, or keep it plugged
+  in with sleep disabled).
 - Keep all state on **named Docker volumes**, never macOS bind mounts — VirtioFS is
   unreliable for advisory locks and `fsync`. ArcticDB data lives in MinIO (the
   `minio-data` volume), so it is unaffected.
 
-## Configuration
-
-All configuration is environment-driven and documented in
-[`.env.example`](https://github.com/oldhero5/energex/blob/main/.env.example); the binding
-lives in `src/energex/core/config.py`. The essentials:
-
-| Variable | Purpose |
-| --- | --- |
-| `MINIO_ENDPOINT` | `host:port` of MinIO. `localhost:9000` locally; `minio:9000` inside the compose network |
-| `ARCTIC_BUCKET`, `ARCTIC_SECURE` | ArcticDB bucket and TLS toggle |
-| `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` | Scoped ArcticDB service-account credentials the app uses |
-| `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD` | MinIO root (compose-only; provisions the scoped account) |
-| `ARCTIC_ACCESS_KEY`, `ARCTIC_SECRET_KEY` | Scoped account `minio-init` creates (mapped into the app's `MINIO_ACCESS_KEY`/`SECRET_KEY`) |
-| `EIA_API_KEY`, `FRED_API_KEY`, `NOAA_TOKEN` | Source connector credentials |
-| `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `NEO4J_AUTH` | Entity graph |
-| `DAGSTER_PG_USERNAME`, `DAGSTER_PG_PASSWORD`, `DAGSTER_PG_DB` | Dagster Postgres |
-
-Containers reach MinIO by the compose **service name** (`minio:9000`), not `localhost`.
-The Dagster instance config and workspace are mounted read-only from
-`deploy/dagster/dagster.yaml` and `deploy/dagster/workspace.yaml`.
-
-See [Operations](./operations.md) for backups, GC, and monitoring.
+See [Operations](./operations.md) for backups, GC, and monitoring, and
+[Quickstart](./quickstart.md) to bring the stack up for the first time.

--- a/website/docs/frontend-integration.md
+++ b/website/docs/frontend-integration.md
@@ -6,91 +6,218 @@ sidebar_label: Frontend Integration
 
 # Frontend Integration
 
-Energex is **open-core**. This repository is the noncommercial data platform; the
-polished cross-device **frontend is a separate, PRIVATE commercial repository**. The two
-never import each other — the only contract between them is the **S2 read API** defined
-here. Freeze this contract before frontend work begins.
+Energex is **source-available** (PolyForm Noncommercial 1.0.0). This repository is the
+power-markets data platform; the polished cross-device **frontend is a separate, PRIVATE
+commercial repository**. The two never import each other — the only contract between them
+is the **S2 read API** (`energex.service.readapi:app`) documented here.
 
-See the design brief [`docs/2026-06-18-s4-frontend-experience-design.md`](https://github.com/oldhero5/energex/blob/main/docs/2026-06-18-s4-frontend-experience-design.md)
-for the product vision (the cinematic lobby, the instrument-grade cockpit, and the
-headline `as_of` time-travel slider).
+The S2 read API is a thin, **read-only** FastAPI seam over [`energex.core.storage`](./storage-point-in-time.md).
+It is **point-in-time first**: every data endpoint takes an optional `as_of` (ISO datetime)
+and defaults to the latest committed vintage when omitted. It opens ArcticDB read-only
+using the same URI grammar and credentials as the [orchestration](./orchestration.md) write
+side (`MINIO_*` / `ARCTIC_BUCKET` from the environment); the connection URI embeds the S3
+secret and is **never logged**.
 
 ## The open-core boundary
 
 ```
 energex (THIS repo)                     energex-app (SEPARATE, PRIVATE repo)
 PolyForm Noncommercial (source-avail)   proprietary / commercial
-data platform + analytics + S2 API      the frontend experience (the paid offering)
+power data platform + S2 read API       the frontend experience (the paid offering)
         │                                          │
         └──────── S2 read API (JSON, as_of) ───────┘
 ```
 
-- **Open-core monetization.** The platform stays free for individuals; the app is the
-  paid product, with no license friction between them.
-- **Decoupled evolution.** The only contract is the S2 read API. This repo owns and
-  freezes it; the private app consumes it. Neither repo imports the other.
-- **Security.** The app NEVER touches ArcticDB/MinIO directly. It only calls S2, which is
-  the single read seam and the place auth/rate-limiting will live.
+- **Decoupled evolution.** The only contract is the S2 read API. This repo owns it; the
+  private app consumes it. Neither repo imports the other.
+- **Single read seam.** The app NEVER touches ArcticDB/MinIO directly. It only calls S2,
+  where auth and CORS live (see below).
+- **Point-in-time everywhere.** Every data endpoint accepts an optional `as_of`, which is
+  what drives the frontend's time-travel slider.
 
-## The read API contract
+## Where the API runs
 
-The S2 read API (`energex.service.readapi:app`) is a thin, **read-only** FastAPI app over
-`energex.core.storage`. It opens ArcticDB read-only using the same URI grammar and
-credentials as the orchestration write side (`MINIO_*` / `ARCTIC_BUCKET` from the
-environment); the connection URI embeds the S3 secret and is never logged.
+The `api` service in [compose](./deployment.md) runs
+`uvicorn energex.service.readapi:app --workers 1`.
 
-`as_of` is first-class: every data endpoint accepts an **optional** `as_of` ISO datetime
-query parameter and defaults to the **latest committed vintage** when omitted.
+| Caller | Base URL |
+|---|---|
+| In-network (other compose services, e.g. the frontend container) | `http://api:8001` |
+| Host / LAN (published port) | `http://<host>:8000` |
+
+The compose `frontend` service is passed `ENERGEX_API_URL=http://api:8001` and depends on
+the `api` service. From a browser or a host process, use the published port `:8000`.
+
+## Endpoints
+
+`as_of` is **knowledge time** (when Energex learned a value), not valid time. Omit it for
+the latest committed vintage; set it to reconstruct the world as it was known at that
+instant. An `as_of` earlier than the first committed vintage returns an empty series and
+never leaks the future.
 
 | Method & path | Query params | Returns |
 |---|---|---|
-| `GET /healthz` | — | `{status, libraries, latest_as_of}` (cheap probe) |
-| `GET /libraries` | — | the ArcticDB libraries present |
-| `GET /symbols` | `library` | symbols in a library (the `*__vintages` sidecars are hidden) |
-| `GET /series` | `library`, `symbol`, `as_of?`, `start?`, `end?` | `read_as_of` rows as JSON records |
-| `GET /curve` | `commodity`, `as_of?` | the assembled forward curve as JSON records |
+| `GET /healthz` | — | `{status, libraries, latest_as_of}` (cheap probe; never auth-gated) |
+| `GET /libraries` | — | `["power.lmp", "power.demand", …]` — the ArcticDB libraries present |
+| `GET /symbols` | `library` (required) | symbols in a library (the `*__vintages` sidecars are hidden) |
+| `GET /series` | `library`, `symbol` (required); `as_of`, `start`, `end` (optional) | `read_as_of` rows as JSON records |
+| `GET /curve` | `commodity` (required); `as_of` (optional) | the assembled forward curve as JSON records |
 
-### `as_of` semantics
+### `GET /healthz`
 
-`as_of` is **knowledge time** (when something became known), not valid time. With
-`as_of` omitted you get the latest committed vintage. With `as_of` set you get the world
-**as it was known at that instant** — earlier than the first committed vintage returns an
-empty series. This is what drives the frontend's time-travel slider.
+Cheap liveness/readiness probe. `latest_as_of` is the most recent committed knowledge time
+across all symbols, computed by reading only the small `*__vintages` sidecars (never the
+heavy series data). This endpoint is **never** auth-gated.
 
-### The reconstructed-vintage flag (the honesty boundary)
+```json
+{
+  "status": "ok",
+  "libraries": ["power.lmp", "power.demand", "power.demand_forecast"],
+  "latest_as_of": "2026-06-28T14:00:00"
+}
+```
+
+### `GET /libraries`
+
+The ArcticDB libraries present, e.g. `power.lmp`, `power.dalmp`, `power.load`,
+`power.demand`, `power.demand_forecast`, `power.generation`, `power.interchange`,
+`power.generation_by_fuel`, `prices.spot`, `fundamentals.eia`, `weather`.
+
+```json
+["power.lmp", "power.dalmp", "power.load", "power.demand"]
+```
+
+### `GET /symbols?library=power.lmp`
+
+Symbols in a library. Power symbols are the bare lowercased codes — balancing-authority
+codes for EIA-930 (`erco`, `ciso`, …) and settlement-point codes for ERCOT. The internal
+`*__vintages` sidecars are filtered out. Returns `404` for an unknown library.
+
+```json
+["hb_hubavg", "hb_north", "hb_houston"]
+```
+
+### `GET /series?library=…&symbol=…`
+
+The `read_as_of` rows for one symbol as JSON records. Each record carries the `Datetime`
+index (the valid time, ISO 8601), the value columns, and the provenance columns including
+`vintage_reconstructed` (see [the honesty boundary](#the-reconstructed-vintage-flag)).
+`NaN` serializes to `null`.
+
+- `as_of` (optional) — knowledge time; defaults to the latest committed vintage.
+- `start`, `end` (optional) — bound the valid-time range. Supplying either makes the read
+  a **bounded** read.
+
+Returns `404` for an unknown library or symbol, `400` for an unparseable datetime.
+
+```json
+[
+  {
+    "Datetime": "2026-06-28T13:00:00.000Z",
+    "instrument_id": "ERCOT.SPP.HB_HUBAVG",
+    "value": 42.17,
+    "vintage_reconstructed": false
+  }
+]
+```
+
+#### The full-history row cap (`413`)
+
+An **unbounded** `/series` read (no `start`/`end`) is capped so a single request cannot
+serialize an arbitrarily large series into one response. If the result exceeds the cap the
+endpoint returns **`413`** with a detail telling you to narrow with `start`/`end`. The cap
+defaults to `500000` rows and is configurable via the `ENERGEX_SERIES_MAX_ROWS`
+environment variable. **Intentional bounded reads (with `start` and/or `end`) are exempt.**
+
+```json
+{ "detail": "series has 812345 rows (> 500000); narrow with start/end" }
+```
+
+### `GET /curve?commodity=…`
+
+The assembled forward curve for a commodity as JSON records, optionally `as_of` a past
+knowledge time. Returns `404` for an unknown commodity.
+
+### The reconstructed-vintage flag
 
 Every `/series` (and `/curve`) record carries `vintage_reconstructed: bool`. `true` marks
 a **reconstructed baseline** (a best-effort backfill, not a true point-in-time forward
 vintage); `false` marks a **true** vintage. The flag is per-row, so a series can mix a
-reconstructed baseline with later true revisions — the frontend recolors/badges
-reconstructed data so the honesty boundary is always visible. Never present reconstructed
-data as if it were a true forward vintage.
+reconstructed baseline with later true revisions. The frontend recolors/badges
+reconstructed data so the honesty boundary is always visible — never present reconstructed
+data as if it were a true forward vintage. See [storage & point-in-time](./storage-point-in-time.md)
+for the full bitemporal model.
 
-## Running the frontend with the platform
+## Auth (optional API key)
 
-The frontend lives in a separate private repo. Check it out into `./frontend` (this path
-is **gitignored** in this repo — the compose `frontend` service builds from it and is
-inert until the repo is present):
-
-```bash
-# from the repo root
-git clone git@github.com:<org>/energex-app.git frontend
-```
-
-The compose `frontend` service passes `ENERGEX_API_URL=http://api:8001` (the in-network
-S2 read API) and depends on the `api` service. Bring up the read-path stack (MinIO + the
-S2 API + the frontend):
+Auth is **opt-in**. When the `ENERGEX_READ_API_KEY` environment variable is set, every
+data endpoint (`/libraries`, `/symbols`, `/series`, `/curve`) requires a matching
+`X-API-Key` header, compared in constant time. `/healthz` stays open so probes keep
+working. When the variable is **unset** the API is open and logs a startup warning. A
+missing or invalid key returns **`401`**.
 
 ```bash
-docker compose --profile frontend up
+curl -H "X-API-Key: $ENERGEX_READ_API_KEY" \
+  "http://localhost:8000/series?library=power.lmp&symbol=hb_hubavg&start=2026-06-01"
 ```
 
-This starts `minio`, `minio-init`, `api`, and `frontend`. To also run the write side
-(Dagster ingestion) use the full stack:
+## CORS (opt-in, origin-scoped)
+
+Cross-origin access is **opt-in** and origin-scoped. `ENERGEX_CORS_ORIGINS` is a
+comma-separated allow-list (e.g. the frontend's origin); only `GET` is allowed. Unset
+means no cross-origin access (the safe default).
 
 ```bash
-docker compose --profile full up
+ENERGEX_CORS_ORIGINS=https://app.example.com,http://localhost:5173
 ```
 
-The Dagster operator console (`:3000`) is **not** part of the product — it is the
-operator surface, out of scope for the frontend.
+## Example fetches
+
+```bash
+# Liveness + latest knowledge time (no key required)
+curl http://localhost:8000/healthz
+
+# Discover libraries, then symbols in one
+curl http://localhost:8000/libraries
+curl "http://localhost:8000/symbols?library=power.lmp"
+
+# A bounded series read (exempt from the 413 cap)
+curl "http://localhost:8000/series?library=power.lmp&symbol=hb_hubavg&start=2026-06-01&end=2026-06-28"
+
+# Time-travel: the same series as it was KNOWN at a past instant
+curl "http://localhost:8000/series?library=power.demand_forecast&symbol=erco&as_of=2026-06-20T00:00:00"
+
+# Forward curve, as known today
+curl "http://localhost:8000/curve?commodity=henryhub"
+```
+
+```ts
+// From the private frontend (in-network base URL, with the optional key)
+const API = process.env.ENERGEX_API_URL ?? "http://api:8001";
+
+async function series(library: string, symbol: string, asOf?: string) {
+  const u = new URL(`${API}/series`);
+  u.searchParams.set("library", library);
+  u.searchParams.set("symbol", symbol);
+  if (asOf) u.searchParams.set("as_of", asOf);
+  const res = await fetch(u, { headers: { "X-API-Key": process.env.ENERGEX_READ_API_KEY ?? "" } });
+  if (res.status === 413) throw new Error("unbounded read too large — pass start/end");
+  if (!res.ok) throw new Error(`S2 ${res.status}`);
+  return res.json();
+}
+```
+
+## Running the read-path stack
+
+The frontend lives in a separate private repo. Check it out into `./frontend` (gitignored
+here — the compose `frontend` service builds from it and is inert until the repo is
+present), then bring up the stack:
+
+```bash
+docker compose --profile full up -d
+```
+
+This starts MinIO, the Dagster write side, and the `api` (S2 read API) service. The
+Dagster operator console (`:3000`) is the operator surface — out of scope for the product.
+See [deployment](./deployment.md) and [operations](./operations.md) for the full topology,
+and [data sources & connectors](./data-sources-connectors.md) for what fills the libraries.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -7,21 +7,46 @@ slug: /
 
 # Energex
 
-**Energex is a self-hosted, always-on energy-market data platform with a bitemporal
+**Energex is a self-hosted, always-on power-markets data platform with a bitemporal
 (point-in-time-correct) store of record.**
 
-It continuously ingests public energy data — EIA fundamentals, NOAA weather, FRED
-benchmark spot prices, and (in development) intraday futures — runs every batch through
-a quality gate, and commits it to a versioned ArcticDB store on MinIO. The store
-remembers not only *what* a value was, but *when each value became known*, so you can
-reconstruct exactly what the data looked like at any past moment.
+It continuously ingests public power-grid data, runs every batch through a quality gate,
+and commits it to a versioned ArcticDB store on MinIO. The store remembers not only
+*what* a value was, but *when each value became known*, so you can reconstruct exactly
+what the data looked like at any past moment. Oil, gas, and weather are kept as
+supporting context — power is the focus.
+
+## What it ingests
+
+Power is primary, and every source below is live:
+
+- **EIA-930 Hourly Electric Grid Monitor** — the only required credential is
+  `EIA_API_KEY`. Covers all ~65–73 US balancing authorities: hourly demand,
+  day-ahead demand forecast, net generation, and interchange
+  (`power.demand` / `power.demand_forecast` / `power.generation` / `power.interchange`),
+  plus net generation **by fuel type** (`power.generation_by_fuel`). Connectors
+  `Eia930RegionConnector` and `Eia930FuelConnector`; instrument ids
+  `EIA930.{D,DF,NG,TI,GEN_FUEL}.<BA>` (symbol is the BA lowercased, e.g. `erco`, `ciso`).
+- **ERCOT public API** — Azure AD B2C auth with an APIM subscription key
+  (`ERCOT_USERNAME` / `ERCOT_PASSWORD` / `ERCOT_API_KEY_PRIMARY`). Real-time 15-minute
+  settlement-point prices (`power.lmp`, `ERCOT.SPP.<sp>`), day-ahead hourly SPP
+  (`power.dalmp`, `ERCOT.DASPP.<sp>`) for the 13 trading hubs and load zones, and
+  ERCOT-wide actual system load (`power.load`, `ERCOT.LOAD.ERCOT`). Central Prevailing
+  Time is converted to UTC, DST-correct.
+
+Supporting context (deprioritized but live): EIA v2 weekly Lower-48 gas storage and US
+crude stocks ex-SPR (`fundamentals.eia`), FRED daily WTI/Brent/Henry Hub spot
+(`prices.spot`), and NOAA nClimDiv monthly HDD/CDD by region (`weather`). A
+dev-only yfinance intraday connector exists for CL/BZ/NG but is **not** scheduled.
+
+See [Data Sources & Connectors](./data-sources-connectors.md) for the full matrix.
 
 ## The problem it solves
 
-Government and market data is **revised**. The U.S. Energy Information Administration
-(EIA) restates weekly gas-storage and crude-stock figures for weeks after first
-publication. NOAA reissues its monthly degree-day files. A naive database overwrites the
-old number with the new one and silently rewrites history.
+Government and market data is **revised**. The EIA restates weekly gas-storage and
+crude-stock figures for weeks after first publication. ERCOT and EIA-930 correct grid
+values inline. NOAA reissues its monthly degree-day files. A naive database overwrites
+the old number with the new one and silently rewrites history.
 
 That quietly corrupts any backtest. If your model is trained or evaluated against data
 that has since been revised, it is learning from numbers that *were not knowable* at the
@@ -31,26 +56,31 @@ decision point — so the backtest looks better than reality ever could.
 
 Energex records every observation against two independent clocks:
 
-- **`valid_time`** — the period the row describes (for example, the week ending
-  2026-05-30).
+- **`valid_time`** — the period the row describes (for example, the hour beginning
+  2026-05-30 14:00 UTC).
 - **`as_of`** — the knowledge/release time: *when Energex learned this value.*
 
 A single query answers "what did we know, and when did we know it":
 
 ```python
+from energex.core.storage import read_as_of
+
 # What the series looked like as it was known on 2026-05-15.
-df = read_as_of(symbol, as_of="2026-05-15")
+df = read_as_of(lib, symbol, as_of="2026-05-15")
 ```
 
-`read_as_of` never leaks the future: it returns only data whose knowledge time is at or
-before the requested `as_of`.
+`read_as_of` never leaks the future: it resolves against the *committed* vintage index
+and returns only data whose knowledge time is at or before the requested `as_of`. Omit
+`as_of` and you get the latest committed vintage. See
+[Storage & Point-in-Time](./storage-point-in-time.md) for the revision modes
+(`degenerate`, `bitemporal_merge`, `bitemporal_replace`) and the commit protocol.
 
 ## The honesty boundary
 
-Upstream sources like EIA and ERCOT revise **inline** and expose no vintage parameter.
-That means true point-in-time history can only accrue **going forward**, from the day
-Energex starts watching a series. Any history captured later by backfilling is, by
-definition, a snapshot of *already-revised* data — not what was observed at the time.
+Upstream sources like EIA-930 and ERCOT revise **inline** and expose no vintage
+parameter. That means true point-in-time history can only accrue **going forward**, from
+the day Energex starts watching a series. Any history captured later by backfilling is,
+by definition, a snapshot of *already-revised* data — not what was observed at the time.
 
 Energex never pretends otherwise. Backfilled rows are flagged
 `vintage_reconstructed=True`, so a backtest can exclude (or specially handle)
@@ -61,15 +91,23 @@ vintages. **That honesty flag is the platform's core invariant.**
 
 - A **pure domain core** (`energex.core`) — connectors, the bitemporal storage layer,
   a pandera quality gate, symbology, and configuration — with zero framework imports.
-- A **Dagster orchestration layer** that schedules ingestion, runs quality checks, and
-  keeps the store current with no manual intervention.
-- An **always-on Docker stack** (MinIO, Dagster, Neo4j) you can run on a single host.
-- Reserved layers for a read API (S2), an analytical agent (S3), and a commercial
-  frontend (S4) — see the [Roadmap](./roadmap.md).
+- A **Dagster orchestration layer** (one asset per series) that schedules ingestion,
+  re-runs the quality gate as a read-back check, and keeps the store current with no
+  manual intervention. See [Orchestration](./orchestration.md).
+- A **live S2 read API** (`energex.service.readapi`, FastAPI) with `as_of` as a
+  first-class parameter on every data endpoint: `/healthz`, `/libraries`, `/symbols`,
+  `/series`, and `/curve`. Optional API-key auth (`ENERGEX_READ_API_KEY`) and
+  origin-scoped CORS. This API is the only contract the separate private frontend
+  consumes — see [Frontend Integration](./frontend-integration.md).
+- An **always-on Docker stack** (MinIO, Dagster + Postgres, the read API, optional
+  Neo4j) you can run on a single host with `docker compose --profile full up -d`.
 
 ## Where to next
 
-- [Architecture](./architecture.md) — the hexagonal layout and the bitemporal model.
 - [Quickstart](./quickstart.md) — run the whole stack in a couple of commands.
+- [Architecture](./architecture.md) — the hexagonal layout and the bitemporal model.
 - [Storage & Point-in-Time](./storage-point-in-time.md) — how vintages, revision modes,
   and the commit protocol actually work.
+- [Deployment](./deployment.md) and [Operations](./operations.md) — running and keeping
+  the platform healthy.
+- [Roadmap](./roadmap.md) — what's live and what's reserved (S3 agent, S4 frontend).

--- a/website/docs/operations.md
+++ b/website/docs/operations.md
@@ -6,87 +6,191 @@ sidebar_label: Operations
 
 # Operations
 
-Day-to-day running of the always-on stack: monitoring, orphan reconciliation, garbage
-collection, and backups.
+Day-to-day running of the always-on power-data platform: the schedules and their
+cadence, monitoring materializations and asset checks in the Dagster UI, querying the
+S2 read API, backfilling a partition range, and troubleshooting freshness and
+credentials. For bringing the stack up, see [Deployment](./deployment.md); for the
+ingestion model, see [Orchestration](./orchestration.md).
 
-## Monitoring
+## Schedules
 
-- **Dagster UI** (http://localhost:3000) is the operator console: schedule status, run
-  history, asset materializations and their metadata (rows written, versions, source
-  URL, `vintage_reconstructed`), and asset-check results.
-- **MinIO console** (http://localhost:9001) shows the ArcticDB bucket and object usage.
-- Every service has a Docker **healthcheck** (the Dagster webserver hits
-  `/server_info`, the daemon runs `dagster-daemon liveness-check`, MinIO hits its health
-  endpoint). `docker compose ps` shows health at a glance.
-- Logs rotate automatically (`json-file`, 10 MB × 5 files per service).
+Every series is its own Dagster asset (fetch → `core.quality.validate` →
+`storage.commit_vintage`/`write_bars`) wrapped in a partitioned job. Each schedule ships
+`default_status=RUNNING`, so the daemon starts firing them the moment the stack comes up.
+On every tick a schedule materializes the **most recent partition** resolved against the
+tick's scheduled execution time. Crons set an explicit `execution_timezone` — the backend
+runs `TZ=UTC`, so wall-clock release times live only in the schedule and the cadence stays
+DST-correct.
 
-## Orphan reconciliation
+| Schedule | Cron | TZ | Cadence | Asset(s) |
+| --- | --- | --- | --- | --- |
+| `eia930_schedule` | `20 * * * *` | America/New_York | hourly (~1–2h lag) | `eia930_region`, `eia930_generation_by_fuel` |
+| `ercot_rt_spp_schedule` | `25 * * * *` | America/Chicago | hourly, current operating day | `ercot_rt_spp` |
+| `ercot_load_schedule` | `35 * * * *` | America/Chicago | hourly, current operating day | `ercot_load` |
+| `ercot_dam_spp_schedule` | `0 14 * * *` | America/Chicago | daily 14:00 CPT, **next** operating day | `ercot_dam_spp` |
+| `fred_spot_prices_schedule` | `30 9 * * 1-5` | America/New_York | weekday mornings | `fred_spot_prices` |
+| `eia_gas_storage_schedule` | `35 10 * * 4` | America/New_York | Thursday (post-release) | `eia_gas_storage` |
+| `eia_petroleum_status_schedule` | `35 10 * * 3` | America/New_York | Wednesday (post-release) | `eia_petroleum_status` |
+| `noaa_degree_days_schedule` | `0 12 6 * *` | America/New_York | 6th of each month | `noaa_degree_days` |
 
-The commit protocol writes data, then appends to the per-symbol version index — and that
-index append is the atomic commit point (see
-[Storage & Point-in-Time](./storage-point-in-time.md)). A crash *between* the two steps
-leaves an **orphan**: a data version with no committed index entry. Orphans are invisible
-to readers (all reads resolve against the committed index), but they should be cleaned up.
+`intraday_futures_bars` is intentionally **not** scheduled — yfinance is dev-only, so a tick
+would only fire failing runs. Materialize it by hand if you want it.
 
-`energex.core.storage.reconcile_orphans` does exactly that — it deletes every data
-version that has no committed index entry and returns the list of removed versions:
+### ERCOT operating-day targeting
 
-```python
-from energex.core import storage
+The EIA-930, FRED, EIA-weekly and NOAA schedules use the generic "latest available
+partition" heuristic. ERCOT does not: its partitions are keyed by the **Central-time
+operating day**, and the latest-ended partition lags a full day. Instead:
 
-removed = storage.reconcile_orphans(lib, symbol)   # -> list[int] of deleted versions
+- **RT SPP and load** target the **current** operating day (`day_offset=0`) and
+  re-materialize it hourly, so today's curve fills in as 15-minute SPPs and hourly load
+  post intraday.
+- **DAM SPP** targets **tomorrow's** operating day (`day_offset=+1`). The day-ahead market
+  clears ~12:30–13:30 CPT, so the 14:00 tick fetches the next day's cleared curve.
+
+If the target partition is not yet in range the schedule emits a `SkipReason` rather than a
+failed run.
+
+## Monitoring in the Dagster UI
+
+The **Dagster UI** (`http://<host>:3000`) is the operator console.
+
+- **Schedules** — confirm every schedule shows green/RUNNING and inspect recent ticks
+  (including `SkipReason`s, which are normal for ERCOT before a partition is in range).
+- **Runs** — materialization history, logs, and failures per asset.
+- **Asset catalog** — each materialization carries metadata: `rows` written,
+  `instrument_id`s, the committed `as_of`, ArcticDB `version`, `source_url`, and
+  `vintage_reconstructed` (true for backfilled rows; see
+  [Storage & Point-in-Time](./storage-point-in-time.md)).
+- **Asset checks** — each series has a read-back check (below). A red check is the first
+  signal that a committed vintage failed re-validation or a symbol went stale.
+
+## Read-back asset checks
+
+Selecting an asset in a job also pulls in its `@asset_check`. After the write, the check
+**reads the committed bars back from ArcticDB and re-runs the same
+`core.quality.validate(<schema>)`** the asset ran — proving the vintage resolves and still
+passes the [quality gate](./orchestration.md). The freshness bound uses the `as_of` the
+asset *committed* (the max read-back `as_of`), not wall-clock now, so a later check run
+cannot false-flag data that was fresh when written.
+
+| Check | Schema | Reads back from |
+| --- | --- | --- |
+| `eia930_region_pass_quality_gate` | `POWER_REGION` | `power.demand`, `power.demand_forecast`, `power.generation`, `power.interchange` |
+| `eia930_generation_by_fuel_pass_quality_gate` | `POWER_GEN_BY_FUEL` | `power.generation_by_fuel` |
+| `ercot_rt_spp_pass_quality_gate` | `ERCOT_SPP` | `power.lmp` |
+| `ercot_dam_spp_pass_quality_gate` | `ERCOT_SPP` | `power.dalmp` |
+| `ercot_load_pass_quality_gate` | `ERCOT_LOAD` | `power.load` |
+| `eia_gas_storage_pass_quality_gate` | `EIA_GAS_STORAGE` | `fundamentals.eia` |
+| `eia_petroleum_status_pass_quality_gate` | `EIA_PETROLEUM` | `fundamentals.eia` |
+| `fred_spot_prices_pass_quality_gate` | `FRED_SPOT` | `prices.spot` |
+| `noaa_degree_days_pass_quality_gate` | `NOAA_HDDCDD` | `weather` |
+| `intraday_bars_pass_quality_gate` | `OHLCV` | `prices.intraday` |
+
+### Per-symbol staleness
+
+The power checks read back **every** symbol across their libraries (skipping the
+`*__vintages` index sidecars). The schema's freshness check uses
+`max(valid_time)` across all symbols, so one balancing authority that quietly stops
+updating would not lower it. To catch that, the power checks compute `max(valid_time)`
+per `instrument_id`, and any symbol lagging the freshest by more than **3 days** is
+surfaced in the check's `stale_symbols` metadata (visible in the UI). The check still
+passes — `stale_symbols` is a watch-list, not a failure — so scan it when an upstream BA
+or settlement point looks suspect.
+
+## Querying the S2 read API
+
+The **S2 read API** (`energex.service.readapi`) is the read seam over the store, served on
+host `:8000` by the compose `api` service. It is point-in-time first: every data endpoint
+takes an optional `as_of` (ISO datetime) and defaults to the latest committed vintage.
+
+```bash
+# Liveness + the latest committed knowledge time across all symbols (open, no key needed)
+curl http://<host>:8000/healthz
+
+# Discover libraries and symbols
+curl http://<host>:8000/libraries
+curl 'http://<host>:8000/symbols?library=power.lmp'
+
+# A bounded series read (ERCOT RT SPP at a hub, by valid_time window)
+curl 'http://<host>:8000/series?library=power.lmp&symbol=hb_hubavg&start=2026-06-01&end=2026-06-02'
+
+# Point-in-time: what did we KNOW about that window as of an earlier instant?
+curl 'http://<host>:8000/series?library=power.lmp&symbol=hb_hubavg&as_of=2026-06-01T18:00:00Z'
+
+# A benchmark forward curve as of a date
+curl 'http://<host>:8000/curve?commodity=WTI&as_of=2026-06-01'
 ```
 
-Committed versions carry UI snapshots; orphans do not, so deleting an orphan never
-touches a live vintage.
+Operational notes:
 
-:::note Reserved: the scheduled reconcile asset
-An out-of-band Dagster reconcile/GC asset (`energex.orchestration.reconcile`) is reserved
-and currently a stub. Until it lands, run `reconcile_orphans` manually (or from a small
-script) if a run is killed mid-commit. In normal operation orphans do not occur.
-:::
+- **Auth** — when `ENERGEX_READ_API_KEY` is set, every data endpoint requires a matching
+  `X-API-Key` header (constant-time compared). `/healthz` stays open. Unset = open API with
+  a startup warning in the logs.
+- **`/series` row cap** — an unbounded full-history read is capped at
+  `ENERGEX_SERIES_MAX_ROWS` (default 500000) and returns **413** if exceeded. Bound the
+  read with `start`/`end` (a bounded read is exempt from the cap).
+- **CORS** — cross-origin access is opt-in and origin-scoped via `ENERGEX_CORS_ORIGINS`
+  (comma-separated allow-list); unset = no cross-origin access.
 
-## Garbage collection
+This API is the only contract the separate private frontend consumes — see
+[Frontend Integration](./frontend-integration.md).
 
-ArcticDB keeps every version. Over time, superseded data versions accumulate. Pruning is
-a deliberate operation — keep enough history to satisfy point-in-time reads back as far
-as you need, then prune older committed versions through ArcticDB's version-management
-APIs. The same reserved reconcile asset is the intended home for a scheduled GC policy.
+## Backfilling a partition range
 
-## Backups
+To rebuild history (or recover a gap), launch a backfill over a partition range from the
+Dagster UI (**Assets → select the asset → Materialize → backfill**) or from the CLI:
 
-There are three independent stores to protect:
+```bash
+docker compose exec dagster-daemon \
+  dagster job backfill ercot_rt_spp_job \
+  --partition-range 2026-06-01:2026-06-07
+```
 
-1. **ArcticDB (the store of record) → the `minio-data` volume.** This is the important
-   one. Back it up by mirroring the bucket to off-host storage with the MinIO client, for
-   example:
+Two honesty boundaries apply to backfills:
 
-   ```bash
-   docker run --rm --network=container:energex-minio \
-     quay.io/minio/mc mirror local/arctic /path/to/backup/arctic
-   ```
+- Backfilled rows are flagged `vintage_reconstructed=True` — true point-in-time history
+  accrues only going forward.
+- ERCOT freshness is validated against the **partition end**, not wall-clock now, so
+  backfilling an old operating day does **not** trip the freshness bound.
 
-   or by snapshotting the `minio-data` Docker volume while the stack is quiesced.
+Because `commit_vintage` is content-idempotent, re-running a partition whose source data is
+unchanged writes **no** new vintage — backfills are safe to re-run.
 
-2. **Dagster history → the `dagster-pg-data` volume.** Standard Postgres backup
-   (`pg_dump` against the `dagster-postgres` container) preserves run/schedule history.
-   This is operational metadata, not market data — lower priority than the store of
-   record.
+## Troubleshooting
 
-3. **Entity graph → the `neo4j-data` volume.** Back up Neo4j with `neo4j-admin database
-   dump` (or snapshot the volume) while the stack is quiesced. The graph only references
-   ArcticDB symbols, so it restores independently of the store of record.
+**A schedule's runs fail immediately.** Almost always a missing or wrong credential. Each
+connector reads its keys from `.env`: `EIA_API_KEY` (EIA-930 and the EIA-weekly
+fundamentals), `ERCOT_USERNAME` / `ERCOT_PASSWORD` / `ERCOT_API_KEY_PRIMARY` (ERCOT B2C
+auth + APIM subscription key), `FRED_API_KEY`, and `NOAA_TOKEN`. Check the failed run's logs
+for the connector's auth/HTTP error before touching anything else. The MinIO/Arctic creds
+(`MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `ARCTIC_ACCESS_KEY`, `ARCTIC_SECRET_KEY`) have no
+defaults — a missing one fails the whole stack, not a single asset.
 
-Restore is the reverse: stop the stack, restore the volume(s) or re-import the snapshot,
-and bring it back up. Because ArcticDB is content-versioned, a restored bucket replays its
-full vintage history exactly.
+**A run succeeds but its asset check is red.** The committed vintage failed re-validation.
+The check metadata names the `schema` and the `failures` count (or `reason` when nothing
+was read back). Inspect the offending series via `/series`.
+
+**An asset check passes but lists `stale_symbols`.** One or more symbols are lagging the
+freshest by more than 3 days. Confirm the upstream BA/settlement point is still publishing;
+EIA-930 and ERCOT data update at least daily, so a persistent laggard is a real signal.
+
+**ERCOT schedules only emit `SkipReason`.** Expected before the targeted operating-day
+partition is in range (e.g. the DAM schedule before tomorrow's partition exists). It
+becomes a problem only if a partition that *should* be in range is being skipped — check the
+schedule's `execution_timezone` and the tick time.
+
+**Health check.** `curl http://<host>:8000/healthz` returns `status`, the library list, and
+`latest_as_of` (the newest committed knowledge time across all symbols, read cheaply from
+the `*__vintages` sidecars). A stale or null `latest_as_of` means nothing has committed
+recently — start at the Dagster schedules.
 
 ## Routine commands
 
 ```bash
-docker compose --profile full ps          # service + health status
-docker compose --profile full logs -f dagster-daemon   # follow a service's logs
+docker compose --profile full ps                         # service + health status
+docker compose --profile full logs -f dagster-daemon     # follow the scheduler's logs
+docker compose --profile full logs -f api                # follow the S2 read API
 docker compose --profile full restart dagster-webserver
-docker compose --profile full down        # stop (keeps volumes)
-docker compose --profile full down -v     # stop AND delete volumes (destroys data)
+docker compose --profile full down                       # stop (keeps volumes)
 ```

--- a/website/docs/orchestration.md
+++ b/website/docs/orchestration.md
@@ -7,8 +7,10 @@ sidebar_label: Orchestration
 # Orchestration
 
 `energex.orchestration` is the **only** layer that imports Dagster. It turns the pure
-core into an always-on pipeline: one asset per source, scheduled releases, post-write
-quality checks, and the resources that connect to MinIO.
+[core](./architecture.md) into an always-on pipeline: one asset per series, a read-back
+quality check on every asset, schedules that all ship **running**, and the resources that
+connect to MinIO. The power feeds (EIA-930, ERCOT) are the focus; oil, gas, and weather
+are supporting context.
 
 The whole thing loads from a single module:
 
@@ -23,59 +25,150 @@ load.
 ## Assets
 
 Each asset follows the same shape: **fetch → quality gate → ArcticDB**, grouping the
-frame by `instrument_id` and routing each through `symbology.resolve`.
+fetched frame by `instrument_id` and routing each group through `symbology.resolve`. The
+write path is either `storage.write_bars` (degenerate, append-with-dedup) or
+`storage.commit_vintage` (bitemporal merge/replace) — see
+[Storage & Point-in-Time](./storage-point-in-time.md).
 
-| Asset | Group | Library | Source | Write path |
+| Asset | Group | Library | Source (cadence) | Write path |
 | --- | --- | --- | --- | --- |
-| `intraday_futures_bars` | prices | `prices.intraday` | yfinance (manual) | `write_bars` (degenerate) |
-| `fred_spot_prices` | prices | `prices.spot` | FRED (daily) | `write_bars` (degenerate) |
-| `noaa_degree_days` | weather | `weather` | NOAA (monthly) | `commit_vintage` (`bitemporal_replace`) |
-| `eia_gas_storage` | fundamentals | `fundamentals.eia` | EIA (weekly) | `commit_vintage` (`bitemporal_merge`) |
-| `eia_petroleum_status` | fundamentals | `fundamentals.eia` | EIA (weekly) | `commit_vintage` (`bitemporal_merge`) |
+| `eia930_region` | `power` | `power.{demand,demand_forecast,generation,interchange}` | EIA-930 (hourly) | `write_bars` (degenerate) |
+| `eia930_generation_by_fuel` | `power` | `power.generation_by_fuel` | EIA-930 (hourly) | `write_bars` (degenerate) |
+| `ercot_rt_spp` | `power` | `power.lmp` | ERCOT RT 15-min SPP (intraday) | `commit_vintage` (`bitemporal_merge`) |
+| `ercot_dam_spp` | `power` | `power.dalmp` | ERCOT day-ahead SPP (daily) | `commit_vintage` (`bitemporal_merge`) |
+| `ercot_load` | `power` | `power.load` | ERCOT actual system load (hourly) | `commit_vintage` (`bitemporal_merge`) |
+| `fred_spot_prices` | `prices` | `prices.spot` | FRED (daily) | `write_bars` (degenerate) |
+| `eia_gas_storage` | `fundamentals_legacy` | `fundamentals.eia` | EIA v2 (weekly) | `commit_vintage` (`bitemporal_merge`) |
+| `eia_petroleum_status` | `fundamentals_legacy` | `fundamentals.eia` | EIA v2 (weekly) | `commit_vintage` (`bitemporal_merge`) |
+| `noaa_degree_days` | `weather` | `weather` | NOAA nClimDiv (monthly) | `commit_vintage` (`bitemporal_replace`) |
+| `intraday_futures_bars` | `prices_legacy` | `prices.intraday` | yfinance (manual) | `write_bars` (degenerate) |
 
-For the bitemporal assets, `as_of` is the run's knowledge time, and the asset decides
-`reconstructed` from the partition's age: if the partition's period closed longer ago
-than a grace window (about 70 days for NOAA, about 10 days for EIA), the run is
-backfilling already-revised data, so the vintage is committed with `reconstructed=True`.
+The EIA-930 region asset fans a single fetch out across the four degenerate libraries
+(`power.demand`, `power.demand_forecast`, `power.generation`, `power.interchange`) by
+routing each `instrument_id` with `symbology.resolve`; one fetch covers **all ~65–73
+balancing authorities**.
+
+### Knowledge time and the honesty boundary
+
+For a live capture, `as_of = fetched_at` — the knowledge time is simply when the run
+pulled the data. For the bitemporal fundamentals/weather assets, the asset additionally
+decides `reconstructed` from the partition's age: if the partition's period closed longer
+ago than a grace window, the run is backfilling **already-revised** data, so the vintage
+is committed with `vintage_reconstructed=True`.
+
+```python
+# assets.py — NOAA whole-file replace; ~70-day grace
+_NOAA_LIVE_GRACE = timedelta(days=70)
+# assets.py — EIA inline-revision; ~10-day grace
+_EIA_LIVE_GRACE = timedelta(days=10)
+```
+
+ERCOT commits always set `reconstructed=False` — the schedules target live operating days
+(below), and the partition-relative freshness check (also below) is what keeps a legitimate
+same-day backfill from being mistaken for stale data. See
+[Storage & Point-in-Time](./storage-point-in-time.md#revision-modes) for why a backfill
+can never claim to be a true forward vintage.
 
 ## Partitions
 
+`partitions.py` keys each series to its natural release period.
+
 | Partition | Definition | Drives |
 | --- | --- | --- |
+| `EIA930_DAILY` | Daily, `start_date="2023-06-01"` (UTC) | `eia930_region`, `eia930_generation_by_fuel` |
+| `ERCOT_DAILY` | Daily, `timezone="America/Chicago"`, `end_offset=2` | `ercot_rt_spp`, `ercot_dam_spp`, `ercot_load` |
 | `EIA_GAS_WEEKLY` | Weekly, `day_offset=4` (Thursday) | `eia_gas_storage` |
 | `EIA_PETROLEUM_WEEKLY` | Weekly, `day_offset=3` (Wednesday) | `eia_petroleum_status` |
 | `NOAA_MONTHLY` | Monthly | `noaa_degree_days` |
 | `FRED_DAILY` | Daily | `fred_spot_prices` |
 
 The partition key indexes the release period; the connector widens its pull to re-carry
-publication lag and inline revisions (EIA looks back at least five weeks; FRED a short
-daily window).
+publication lag and inline revisions (EIA weekly looks back ≥5 weeks; EIA-930 and FRED a
+short daily window).
+
+### ERCOT operating-day mapping
+
+`ERCOT_DAILY` is keyed by the **ERCOT operating day in Central Prevailing Time**, not UTC,
+so a partition key maps 1:1 to an ERCOT delivery day. `end_offset=2` keeps **today and
+tomorrow** as valid keys at once, because the three ERCOT feeds describe different
+operating days:
+
+```python
+# partitions.py
+ERCOT_DAILY = dg.DailyPartitionsDefinition(
+    start_date="2026-06-01", timezone="America/Chicago", end_offset=2
+)
+```
+
+- **RT SPP and system load** describe the **current** operating day, filling in hourly as
+  the day progresses → their schedules target `day_offset=0`.
+- **Day-ahead SPP** clears around 12:30–13:30 CPT for the **next** operating day → its
+  schedule targets `day_offset=1`, fetching tomorrow's curve each afternoon.
+
+The schedule helper `_ercot_day_request` computes the target key directly from the tick
+date plus the offset, rather than "latest ended partition" (which lags a full operating
+day and would be wrong for all three feeds).
 
 ## Schedules
 
-Four schedules are **running by default** (`DefaultScheduleStatus.RUNNING`). Each
-materializes the most recent partition on every tick, with crons expressed in wall-clock
-release time (the backend runs `TZ=UTC`, so `execution_timezone` is always set for
-DST-correct cadence).
+Every schedule ships **running** (`DefaultScheduleStatus.RUNNING`) and sets
+`execution_timezone` explicitly — the backend runs `TZ=UTC`, so wall-clock release times
+live only here and the cadence stays DST-correct. The non-ERCOT schedules materialize the
+**most recent partition** on each tick (`_latest_partition_request`); the ERCOT schedules
+use the operating-day offset described above.
 
-| Schedule | Cron (ET) | Fires |
-| --- | --- | --- |
-| `eia_gas_storage_schedule` | `35 10 * * 4` | Just after the Thursday 10:30 ET EIA gas release |
-| `eia_petroleum_status_schedule` | `35 10 * * 3` | Just after the Wednesday 10:30 ET EIA petroleum release |
-| `noaa_degree_days_schedule` | `0 12 6 * *` | 6th of the month, after the nClimDiv file lands |
-| `fred_spot_prices_schedule` | `30 9 * * 1-5` | Weekday mornings, after FRED's publication lag |
+| Schedule | Cron | TZ | Fires |
+| --- | --- | --- | --- |
+| `eia930_schedule` | `20 * * * *` | America/New_York | Hourly, re-materializes today's EIA-930 partition (~1–2h source lag) |
+| `ercot_rt_spp_schedule` | `25 * * * *` | America/Chicago | Hourly, re-materializes the current operating day (RT lands every 15 min) |
+| `ercot_load_schedule` | `35 * * * *` | America/Chicago | Hourly, re-materializes the current operating day |
+| `ercot_dam_spp_schedule` | `0 14 * * *` | America/Chicago | 14:00 CPT, fetches the next operating day's cleared curve |
+| `eia_gas_storage_schedule` | `35 10 * * 4` | America/New_York | Just after the Thursday 10:30 ET EIA gas release |
+| `eia_petroleum_status_schedule` | `35 10 * * 3` | America/New_York | Just after the Wednesday 10:30 ET EIA crude-stocks release |
+| `noaa_degree_days_schedule` | `0 12 6 * *` | America/New_York | 6th of the month, after the nClimDiv file lands |
+| `fred_spot_prices_schedule` | `30 9 * * 1-5` | America/New_York | Weekday mornings, after FRED's publication lag |
 
-`intraday_futures_bars` is intentionally **not scheduled** — yfinance is frequently
+`intraday_futures_bars` is intentionally **not** scheduled — yfinance is frequently
 blocked, so a tick would only fire failing runs. Run it manually when you want intraday
 data in dev.
 
+### Partition-relative freshness (so backfills pass)
+
+The pandera freshness check (`core.schemas._freshness_check`) bounds `max(valid_time)`
+against an `as_of` supplied per `validate` call — not wall-clock now. The ERCOT assets
+exploit this: they validate against the **partition's end**, so backfilling an old
+operating day does not falsely trip the 2-business-day bound.
+
+```python
+# assets.py — ercot_rt_spp
+result = ErcotRtSppConnector().fetch(day, day)
+return _commit_ercot(context, arctic, result, schemas.ERCOT_SPP, validation_as_of=window.end)
+```
+
+The bitemporal `as_of`/`fetched_at` that get **committed** stay the real knowledge time
+(`result.fetched_at`); only the *freshness validation clock* is moved to the partition end.
+
 ## Asset checks (the quality gate, post-write)
 
-Every source has an `@asset_check` that reads the committed series back from ArcticDB and
-re-runs the **same** `core.quality.validate(...)` the asset ran on the way in
+Every asset has a paired `@asset_check` that reads the committed series **back** from
+ArcticDB and re-runs the **same** `core.quality.validate(...)` the asset ran on the way in
 (re-localizing `valid_time` to UTC, which ArcticDB strips on store). This proves the
-vintage resolves and still passes the gate after a real round-trip. The check is the
-single-sourced gate run twice: once before the write, once after.
+vintage resolves and still passes the gate after a real round-trip — the single-sourced
+gate, run twice: once before the write, once after.
+
+Two details keep the read-back honest:
+
+- **Committed `as_of`, not now.** The freshness re-check uses `_committed_as_of` — the max
+  `as_of` provenance column in the read-back frame — so a check that runs hours later can't
+  false-flag staleness for data that was fresh when written.
+- **Per-symbol staleness surfacing.** The power read-backs (`_power_gate_readback`) span
+  every symbol in a library. Because the schema freshness check keys on
+  `max(valid_time)` across *all* symbols, a single BA that stopped updating wouldn't lower
+  it — so any symbol lagging the freshest by more than `_STALE_SYMBOL_LAG`
+  (`pd.Timedelta(days=3)`) is reported in the check's `stale_symbols` metadata.
+
+UI visibility from checks is best-effort; the durable safety net is the reconcile sweep
+(see [Operations](./operations.md)).
 
 ## Resources
 
@@ -84,19 +177,48 @@ single-sourced gate run twice: once before the write, once after.
 - **`ArcticDBResource`** opens an Arctic client against MinIO in `setup_for_execution`.
   Credentials come from Dagster `EnvVar` (`MINIO_ENDPOINT`, `ARCTIC_BUCKET`,
   `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`). ArcticDB's S3 backend requires the secret
-  embedded in the connection URI, so the URI is **never logged** and any connection
-  error is re-raised with a redacted message (endpoint/bucket only) so the credential
+  **embedded in the connection URI**, so the URI is **never logged** and any connection
+  error is re-raised with a redacted message (endpoint/bucket only), so the credential
   cannot leak through a traceback. It hands out create-if-missing libraries.
-- **`HttpResource`** is a thin `httpx` client factory for keyless/REST connectors.
+- **`HttpResource`** is a thin `httpx` + `tenacity` client factory for keyless/REST
+  connectors.
 
 ## Backfills
 
-Because every asset is partitioned, you can backfill historical data straight from the
-Dagster UI: select an asset, choose a partition range, and launch a backfill. Remember
-the honesty boundary — partitions older than the grace window commit with
+Because every production asset is partitioned, you can backfill historical data straight
+from the Dagster UI: select an asset, choose a partition range, and launch a backfill.
+Remember the honesty boundary — partitions older than the grace window commit with
 `vintage_reconstructed=True`, so the backfilled history is correctly flagged as a
 reconstructed baseline rather than a true forward vintage (see
-[Storage & Point-in-Time](./storage-point-in-time.md)).
+[Storage & Point-in-Time](./storage-point-in-time.md)). The partition-relative freshness
+clock means a same-day ERCOT backfill still passes the gate cleanly.
 
 The Dagster UI runs on **http://localhost:3000** — it is the operator console (see
-[Operations](./operations.md)).
+[Operations](./operations.md) and [Deployment](./deployment.md)).
+
+## Adding a new asset + check + schedule
+
+The layer is deliberately repetitive — every series follows the same three-part pattern.
+To add one:
+
+1. **Connector** — implement it in `energex.core.connectors` returning a `FetchResult`
+   (frame carries `instrument_id`, tz-aware-UTC `valid_time`, value columns), and add its
+   `instrument_id` routing rule in `core.symbology` (see
+   [Data Sources & Connectors](./data-sources-connectors.md)). Add its pandera schema in
+   `core.schemas`.
+2. **Asset** in `assets.py` — fetch → `quality.validate(frame, SCHEMA, as_of=...)` → group
+   by `instrument_id`, `symbology.resolve`, then `storage.write_bars` (degenerate) or
+   `storage.commit_vintage` (bitemporal). Append it to `ASSETS`.
+3. **Asset check** in `checks.py` — read the committed series back, re-run the **same**
+   `quality.validate(...)`, return an `AssetCheckResult`. Append it to `CHECKS`.
+4. **Partition** in `partitions.py` (if the series has a natural release period) and a
+   **schedule** in `schedules.py` with `default_status=dg.DefaultScheduleStatus.RUNNING`
+   and an explicit `execution_timezone`. Append it to `SCHEDULES`.
+
+Everything is auto-wired by `definitions.py` from the `ASSETS` / `CHECKS` / `SCHEDULES`
+lists — there is no central registry to edit beyond appending. Validate the result with
+the Dagster CLI (the same gate CI runs — see [Testing](./testing.md)):
+
+```bash
+uv run dagster definitions validate -m energex.orchestration.definitions
+```

--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -6,58 +6,95 @@ sidebar_label: Quickstart
 
 # Quickstart
 
-There are two ways to run Energex: the **always-on Docker stack** (the real deployment)
-and the **local dev loop** (for working on the code).
+Energex is a self-hosted, always-on **power-markets** data platform. The whole stack —
+the bitemporal ArcticDB store, the Dagster orchestrator that keeps it current, and the
+S2 read API the frontend consumes — comes up with **two commands**.
+
+There are two ways to run it: the **always-on Docker stack** (the real deployment) and
+the **local dev loop** (for working on the code). See [Architecture](./architecture.md)
+for how the pieces fit together.
 
 ## Prerequisites
 
 - Docker / [OrbStack](https://orbstack.dev/) for the always-on stack.
-- [`uv`](https://docs.astral.sh/uv/) and Python 3.10+ for the dev loop.
-- Two free API keys: [EIA](https://www.eia.gov/opendata/register.php) and
-  [FRED](https://fredaccount.stlouisfed.org/apikeys). NOAA and FRED/EIA cover the
-  scheduled sources; everything else is optional.
+- [`uv`](https://docs.astral.sh/uv/) and Python 3.11+ for the dev loop.
+- A free [EIA API key](https://www.eia.gov/opendata/register.php) — this alone unlocks
+  the primary power feed (EIA-930 demand, forecast, generation, interchange, and
+  generation-by-fuel for every US balancing authority).
+- A free [FRED API key](https://fredaccount.stlouisfed.org/apikeys) for the supporting
+  oil/gas benchmark spot feed.
+- ERCOT and NOAA credentials are optional; without them those assets simply stay idle.
+  See [Data Sources & Connectors](./data-sources-connectors.md) for every source.
 
 ## Run the always-on stack
 
 ```bash
-cp .env.example .env        # fill in EIA_API_KEY and FRED_API_KEY; placeholders OK for the rest
+git clone https://github.com/oldhero5/energex.git
+cd energex
+cp .env.example .env
 docker compose --profile full up -d
 ```
 
-The `full` profile starts:
+Before the second command, open `.env` and fill in the **required** values — compose has
+no built-in defaults for these and will refuse to start without them:
+
+| Variable | What it is |
+| --- | --- |
+| `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD` | MinIO root (compose-only; provisions the scoped account) |
+| `ARCTIC_ACCESS_KEY`, `ARCTIC_SECRET_KEY` | Scoped ArcticDB service account `minio-init` creates |
+| `NEO4J_AUTH` | Neo4j container auth, in `user/password` form |
+| `EIA_API_KEY` | EIA-930 power feed + gas/crude fundamentals (the primary source) |
+| `FRED_API_KEY` | Benchmark spot prices (supporting context) |
+
+Keep `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` in `.env` in sync with the scoped
+`ARCTIC_ACCESS_KEY` / `ARCTIC_SECRET_KEY` — the app authenticates with the scoped
+account, never the MinIO root. The full annotated list lives in
+[`.env.example`](https://github.com/oldhero5/energex/blob/main/.env.example); see
+[Deployment](./deployment.md#configuration-required-secrets) for how each variable binds.
+
+### Services the `full` profile starts
 
 | Service | Port | What it is |
 | --- | --- | --- |
+| `api` | 8000 | **S2 read API** — `/series`, `/curve`, `/symbols`, `/libraries`, `/healthz` |
 | `dagster-webserver` | 3000 | Dagster UI — assets, schedules, runs, backfills |
 | `dagster-daemon` | — | Runs schedules and sensors |
 | `dagster-postgres` | — | Dagster instance storage |
 | `minio` | 9000 / 9001 | ArcticDB object store + web console |
 | `minio-init` | — | One-shot: creates the bucket and scoped service account |
 | `neo4j` | 7474 / 7687 | Optional entity graph |
-| `api` | 8000 | S2 read API (`/series`, `/curve`, `/symbols`, `/libraries`) |
 
-Then open:
+The `api` service is the **only** contract the separate, private frontend consumes — see
+[Frontend Integration](./frontend-integration.md).
 
-- **Dagster UI** — http://localhost:3000
-- **MinIO console** — http://localhost:9001
-- **Neo4j browser** — http://localhost:7474
+### Then open
 
-Four schedules run by default and keep the store current with no manual intervention:
+- **Dagster UI** — http://localhost:3000 (assets, schedules, run history, backfills)
+- **MinIO console** — http://localhost:9001 (the ArcticDB object store)
+- **Read API (S2)** — http://localhost:8000 (try `GET /healthz`, then `/libraries`)
+- **Neo4j browser** — http://localhost:7474 (optional graph)
 
-| Schedule | Cadence (ET) | Asset |
+Schedules ship **running**, so the store stays current with no manual intervention. The
+primary power feeds lead the cadence; oil/gas/weather follow as supporting context:
+
+| Schedule | Cadence | Source |
 | --- | --- | --- |
-| EIA gas storage | Thursday 10:35 | `eia_gas_storage` |
-| EIA petroleum status | Wednesday 10:35 | `eia_petroleum_status` |
-| FRED spot prices | Weekday mornings 09:30 | `fred_spot_prices` |
-| NOAA degree days | 6th of the month 12:00 | `noaa_degree_days` |
+| EIA-930 grid monitor | Hourly | Demand, day-ahead forecast, generation, interchange, generation-by-fuel |
+| ERCOT RT + load | Hourly (current operating day) | Real-time 15-min SPP and ERCOT-wide load *(needs ERCOT creds)* |
+| ERCOT day-ahead | Midday (next operating day) | Day-ahead hourly SPP *(needs ERCOT creds)* |
+| FRED spot | Daily (weekday mornings) | WTI / Brent / Henry Hub benchmark spot |
+| EIA fundamentals | Weekly (gas Thu, crude Wed) | Lower-48 gas storage, crude stocks ex-SPR |
+| NOAA degree days | Monthly | HDD/CDD by US region |
 
-To verify it is alive, open the Dagster UI and confirm the four schedules show as
-running, or trigger a single run manually from the asset graph.
+To verify it is alive, open the Dagster UI and confirm the schedules show as running, or
+trigger a single asset run from the asset graph and watch it land in MinIO. Full detail
+in [Orchestration](./orchestration.md) and
+[Storage & Point-in-Time](./storage-point-in-time.md).
 
 :::note Apple Silicon
-ArcticDB has no `arm64` wheel, so the Dagster image is built and run as `linux/amd64`
-under emulation. It works on M-series Macs; cold starts are a little slower. See
-[Deployment](./deployment.md).
+ArcticDB has no `arm64` wheel, so the Dagster and `api` images are built and run as
+`linux/amd64` under emulation. It works on M-series Macs; cold starts are a little
+slower. See [Deployment](./deployment.md).
 :::
 
 ## The dev loop
@@ -71,16 +108,19 @@ uv run ruff check src/energex tests                        # lint
 uv run dagster dev -m energex.orchestration.definitions    # local Dagster UI on :3000
 ```
 
-`uv run dagster dev` still needs a reachable MinIO. The simplest path is to run just the
-storage services from compose while you iterate locally:
+The test suite runs **offline** by default (connectors mocked, storage on LMDB), so
+`uv run pytest` needs nothing running. See [Testing](./testing.md).
+
+`uv run dagster dev`, however, still needs a reachable MinIO. The lighter `dev` profile
+brings up just the storage services so you can iterate locally:
 
 ```bash
-docker compose --profile dev up -d minio minio-init dagster-postgres
+docker compose --profile dev up -d   # minio + minio-init + dagster-postgres
 ```
 
 Point your local process at them by setting `MINIO_ENDPOINT=localhost:9000` and the
 scoped `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` in `.env` (see
-[Configuration in the Deployment guide](./deployment.md#configuration)).
+[Configuration in the Deployment guide](./deployment.md#configuration-required-secrets)).
 
 ## Next steps
 
@@ -88,3 +128,4 @@ scoped `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` in `.env` (see
   add a new source.
 - [Storage & Point-in-Time](./storage-point-in-time.md) — reading vintages with `as_of`.
 - [Orchestration](./orchestration.md) — assets, schedules, and backfills in detail.
+- [Frontend Integration](./frontend-integration.md) — consuming the S2 read API.

--- a/website/docs/roadmap.md
+++ b/website/docs/roadmap.md
@@ -6,70 +6,113 @@ sidebar_label: Roadmap
 
 # Roadmap
 
-Energex is built in stages. S1 (the data platform: core, storage, orchestration) is
-complete and is what this documentation describes. The remaining stages are reserved in
-the package layout and summarized below.
+Energex is built in stages. **S1** (the data platform: core, storage, orchestration) and
+**S2** (the read API) are **done and live** — they are what most of this documentation
+describes. **S3** (an analytical agent) and **S4** (the commercial frontend) are reserved
+in the package layout and summarized below.
+
+| Stage | What | Status |
+| --- | --- | --- |
+| **S1** | Data platform: connectors, bitemporal store, quality gate, Dagster orchestration | **Done** |
+| **S2** | FastAPI read API with `as_of` first-class on every data endpoint | **Done — live** |
+| **S3** | LangGraph analytical agent over the read API | Reserved |
+| **S4** | Immersive cross-device frontend (separate private repo) | Reserved |
 
 ## Focus: power markets
 
 Energex is centered on **power markets**. The **EIA-930 Hourly Electric Grid Monitor**
-(demand, day-ahead forecast, net generation, interchange, and generation-by-fuel for all
-US balancing authorities) ingests hourly today. **ERCOT** nodal data ingests live from the
-ERCOT public API: real-time and day-ahead settlement point prices for the trading hubs and
-load zones, plus ERCOT-wide actual system load. Oil & gas and weather remain ingested as
-supporting context but are no longer the focus. Next on the power track: additional ISOs
-(CAISO, PJM, MISO).
+ingests hourly today for all ~65–73 US balancing authorities: demand (`power.demand`),
+day-ahead forecast (`power.demand_forecast`), net generation (`power.generation`),
+interchange (`power.interchange`), and net generation by fuel type
+(`power.generation_by_fuel`). **ERCOT** nodal data ingests live from the ERCOT public
+API: real-time 15-minute and day-ahead hourly settlement-point prices for the trading
+hubs and load zones (`power.lmp` / `power.dalmp`), plus ERCOT-wide actual system load
+(`power.load`). Oil & gas and weather (FRED spot, EIA fundamentals, NOAA degree days)
+remain ingested as supporting context but are no longer the focus.
 
-## S2 — Serving (read API)
+**Next on the power track:** additional ISOs — **CAISO, PJM, MISO** — each following the
+same connector contract and `power.*` symbology routing already used for EIA-930 and
+ERCOT. See [Data sources & connectors](./data-sources-connectors.md) for the live
+inventory.
 
-A FastAPI read API in `energex.service`, with **`as_of` as a first-class parameter on
-every endpoint**. This is the single read seam — the place auth and rate-limiting live —
-and the only contract the frontend depends on. Indicative surface:
+## S1 — Data platform (done)
+
+The pure domain core (`energex.core`) plus the Dagster orchestration layer. Connectors
+fetch, the pandera quality gate validates every batch, and the bitemporal ArcticDB store
+on MinIO records both *what* a value was and *when* it became known. One Dagster asset per
+series, each with a read-back check and a `RUNNING` schedule. This is the foundation every
+later stage builds on — see [Architecture](./architecture.md),
+[Storage & point-in-time](./storage-point-in-time.md), and
+[Orchestration](./orchestration.md).
+
+## S2 — Read API (done — live)
+
+A thin, read-only FastAPI seam over the bitemporal store (`energex.service.readapi`),
+**served on host `:8000` by the compose `api` service**. It is the single read seam — the
+place auth and rate-limiting live — and the **only contract the separate private frontend
+consumes**. It is **point-in-time first**: every data endpoint takes an optional `as_of`
+(ISO datetime) and defaults to the latest committed vintage.
 
 | Endpoint | Returns |
 | --- | --- |
-| `GET /instruments` | Symbology catalog: what's available, units, revision mode |
-| `GET /curve?commodity=&as_of=` | Dated-futures curve as known at `as_of` |
-| `GET /term-structure?commodity=&as_of=` | Contango/backwardation + roll yield |
-| `GET /volatility?instrument=&method=&as_of=` | Realized / Parkinson / Garman-Klass |
-| `GET /fundamentals?series=&as_of=` | EIA/NOAA with vintage + `reconstructed` flag |
-| `GET /spot?instrument=&as_of=` | FRED benchmark spot |
-| `GET /series/{id}/vintages` | Available knowledge times (drives the time-travel slider) |
-| `POST /agent` (stream) | S3 chat; threads `as_of`; returns text + chart payloads |
+| `GET /healthz` | Liveness, library list, and latest committed `as_of` (open, no key) |
+| `GET /libraries` | The ArcticDB libraries present in the store |
+| `GET /symbols?library=` | Symbols in a library (vintage sidecars excluded) |
+| `GET /series?library=&symbol=&as_of=&start=&end=` | A series as known at `as_of`, optionally windowed |
+| `GET /curve?commodity=&as_of=` | Dated-curve assembly as known at `as_of` |
 
-Every response carries the resolved `as_of` and a `reconstructed: bool`, so consumers
-always know which knowledge time they are looking at and whether it is a true or
-reconstructed vintage.
+Each `/series` row carries its provenance, including the `vintage_reconstructed` flag, so
+consumers always know whether they are looking at a true forward vintage or a
+reconstructed baseline.
 
-## S3 — Agent
+Operational guardrails (all from `energex.service.readapi`):
+
+- **Optional API-key auth** — set `ENERGEX_READ_API_KEY` and every data endpoint requires
+  a matching `X-API-Key` header (constant-time compared); `/healthz` stays open. Unset
+  leaves the API open with a startup warning.
+- **Unbounded-read cap** — `/series` without `start`/`end` returns `413` past
+  `ENERGEX_SERIES_MAX_ROWS` (default `500000`); bound the read with `start`/`end`.
+- **Opt-in CORS** — `ENERGEX_CORS_ORIGINS` is a comma-separated origin allow-list (e.g.
+  the frontend origin); unset means no cross-origin access.
+
+```bash
+# default vintage
+curl 'http://localhost:8000/series?library=power.lmp&symbol=ERCOT.SPP.HB_HOUSTON'
+
+# point-in-time: as the data was known on 2026-06-01, windowed
+curl 'http://localhost:8000/series?library=power.demand&symbol=erco&as_of=2026-06-01T00:00:00Z&start=2026-05-01&end=2026-06-01'
+```
+
+Run it standalone with `uvicorn energex.service.readapi:app --workers 1`. See
+[Deployment](./deployment.md) and [Frontend integration](./frontend-integration.md).
+
+## S3 — Agent (reserved)
 
 A LangGraph analytical agent in `energex.agent`, read-only, that threads `as_of` through
-its queries so every answer is point-in-time correct. It calls the S2 API rather than
-touching storage directly.
+its queries so every answer is point-in-time correct. It calls the **live S2 API** rather
+than touching storage directly — no new read path, no future leakage.
 
-## S4 — Frontend (the commercial product)
+## S4 — Frontend (the commercial product, reserved)
 
 The immersive, cross-device application — and the commercial offering — lives in a
 **separate, private repository**. It is the paid product; this platform stays
 source-available and free for noncommercial use. The two repos are joined only by the S2
 read API: neither imports the other, and the app never touches ArcticDB/MinIO directly.
 
-The design north star is an immersive, cinematic experience (WebGL/Three.js,
-scroll-driven onboarding) wrapped around an instrument-grade daily "cockpit." The
-headline interaction is an **`as_of` time-travel slider** that scrubs through knowledge
-time and visibly recolors any series that is a **reconstructed** baseline versus a
-**true** forward vintage — making the platform's honesty boundary a tangible product
-feature.
+The design north star is an immersive, cinematic experience (WebGL/Three.js, scroll-driven
+onboarding) wrapped around an instrument-grade daily "cockpit." The headline interaction is
+an **`as_of` time-travel slider** that scrubs through knowledge time and visibly recolors
+any series that is a **reconstructed** baseline versus a **true** forward vintage — making
+the platform's honesty boundary a tangible product feature.
 
 The full brief — including the open-core boundary diagram, the responsive-PWA strategy,
-the design system, and the milestone plan (freeze the S2 contract → cockpit MVP → PWA
-polish → signature 3D + immersive lobby → agent → commercial hardening) — lives in the
-repository at `docs/2026-06-18-s4-frontend-experience-design.md`:
+the design system, and the milestone plan — lives in the repository at
+`docs/2026-06-18-s4-frontend-experience-design.md`:
 
 - [S4 Frontend Experience Design (brief)](https://github.com/oldhero5/energex/blob/main/docs/2026-06-18-s4-frontend-experience-design.md)
 
 ## The through-line
 
 Every stage serves the same invariant: **point-in-time correctness with a visible honesty
-boundary.** The store records it (S1), the API exposes it (S2), the agent respects it
-(S3), and the frontend makes it something you can see and feel (S4).
+boundary.** The store records it (S1), the **live** read API exposes it (S2), the agent
+respects it (S3), and the frontend makes it something you can see and feel (S4).

--- a/website/docs/storage-point-in-time.md
+++ b/website/docs/storage-point-in-time.md
@@ -8,48 +8,75 @@ sidebar_label: Storage & Point-in-Time
 
 The storage layer (`energex.core.storage`) is the crown jewel: a bitemporal store of
 record built on ArcticDB-on-MinIO, with a per-symbol version index that makes
-point-in-time reads correct and crash-safe.
+point-in-time reads correct and crash-safe. Every power series — EIA-930 demand,
+forecast, generation, interchange, and net generation by fuel for ~65–73 balancing
+authorities, plus ERCOT real-time / day-ahead SPP and system load — lands here, and so
+do the supporting oil, gas, and weather series. The store records both **what** a value
+was and **when** Energex learned it.
+
+## Two clocks
+
+Every row lives on two axes:
+
+- **`valid_time`** — the period the row *describes* (the operating hour, the settlement
+  interval, the release week). Required on every inbound frame; tz-aware UTC.
+- **`as_of`** — the knowledge time, *when Energex learned* this value. Set by the
+  orchestration layer per vintage.
+
+`read_as_of(lib, symbol, as_of=...)` reconstructs what was known at a past knowledge time
+and **never leaks the future**. This is what makes a backtest honest: ask for `as_of` =
+your decision date, and you get exactly what was knowable then. See
+[Architecture](./architecture.md) for the conceptual model and
+[Orchestration](./orchestration.md) for where `as_of` and `reconstructed` are decided.
 
 ## The canonical frame
 
-Before any write, a frame is canonicalized:
+Before any write, `_canonicalize` normalizes a frame:
 
-- `valid_time` is required, converted to tz-aware UTC then stored tz-naive UTC (ArcticDB
-  strips timezones on store), and used as a sorted, de-duplicated `DatetimeIndex` named
-  `Datetime`.
+- `valid_time` is required (`StorageError` otherwise), parsed as UTC, then stored
+  **tz-naive UTC** (ArcticDB strips timezones on store) as a sorted, de-duplicated
+  `DatetimeIndex` named `Datetime` (keeping the last value per duplicate).
 - Provenance columns are stamped on: `as_of`, `source`, `source_url`, `fetched_at`, and
   `vintage_reconstructed`.
 
+```python
+VINTAGE_COLS = ("as_of", "version", "fetched_at", "vintage_reconstructed")
+```
+
 ## Revision modes
 
-Each symbol has exactly one revision mode (routed by `energex.core.symbology`):
+Each symbol has exactly one revision mode, routed by `energex.core.symbology` (the
+rule-based `power.*` router, or the static reverse index for supporting series).
 
 ### `degenerate` — `write_bars`
 
-For never-revised streams (FRED spot, intraday bars). `write_bars` appends with
-de-duplication on the UTC index:
+For never-revised streams (FRED WTI/Brent/Henry Hub spot, EIA-930 region series, dev-only
+intraday bars). `write_bars` appends with de-duplication on the UTC index:
 
 - First write creates the symbol.
-- If the new rows are strictly after the existing tail, it uses a fast `append`.
+- If the new rows are strictly after the existing tail (`new.index.min() >
+  existing.index.max()`), it uses a fast `lib.append`.
 - Otherwise (sparse interior inserts) it reads, concatenates, de-duplicates keeping the
   last value, and rewrites.
 - If nothing is new, it is an idempotent no-op.
 
-It deliberately never calls `lib.update(date_range)` — that would delete bars omitted
+It deliberately **never** calls `lib.update(date_range)` — that would delete bars omitted
 from the window. There is no vintage index for degenerate symbols; `as_of` equals
-`fetched_at`.
+`fetched_at`. Because `power.*` symbols are high-cardinality and not in the static reverse
+index, the asset passes `mode` explicitly; `write_bars` refuses any non-degenerate symbol.
 
 ### `bitemporal_replace` — `commit_vintage`
 
-For sources where each release is a *complete* as-known series (NOAA). Every commit is a
-full versioned write at a new `as_of`.
+For sources where each release is a *complete* as-known series (NOAA nClimDiv HDD/CDD).
+Every commit is a full versioned write at a new `as_of`.
 
 ### `bitemporal_merge` — `commit_vintage`
 
-For sources that revise a window *inline* (EIA). Before writing, `commit_vintage` reads
-the full as-known series committed **strictly before** this `as_of` (no future leak) and
-merges the revision onto it: revisions overwrite by exact `valid_time`, and prior rows
-absent from the new frame survive.
+For sources that revise a window *inline* — ERCOT real-time / day-ahead SPP and load, and
+the EIA weekly fundamentals. Before writing, `commit_vintage` reads the full as-known
+series committed **strictly before** this `as_of` (no future leak) and merges the revision
+onto it: revisions overwrite by exact `valid_time`, and prior rows absent from the new
+frame survive.
 
 ```python
 def _merge_revisions(prior, frame):
@@ -60,8 +87,26 @@ def _merge_revisions(prior, frame):
     return pd.concat([kept, frame]).sort_index()
 ```
 
-`commit_vintage` is **idempotent**: if a vintage with the same `as_of` already exists, it
-returns the existing version and never re-mutates a live vintage (unless `force=True`).
+The prior series comes from `_read_full_series_before`, which selects the greatest
+committed `as_of` **strictly less than** this one — so a merge can never fold in a future
+revision.
+
+## Idempotency: two layers
+
+`commit_vintage` is idempotent on two distinct grounds, and either short-circuits the
+write:
+
+1. **as_of idempotency.** If a vintage with the same `as_of` already exists in the index,
+   it returns the existing version and never re-mutates a live vintage (unless
+   `force=True`).
+2. **Content idempotency.** Even under a *new* `as_of`, if the canonical payload matches
+   the latest committed vintage, the commit adds no knowledge and is skipped (the existing
+   version is returned). `_same_payload` compares the index and all **non-provenance**
+   columns — `as_of`, `source`, `source_url`, `fetched_at`, `vintage_reconstructed` are
+   excluded, because an unchanged re-pull under a fresh `as_of` is not new knowledge.
+
+Content idempotency is what keeps an hourly, full-history re-pull (the ERCOT case) from
+writing a brand-new vintage every run; without it the store would grow unbounded.
 
 ## The version index is the commit point
 
@@ -72,15 +117,17 @@ index lives at the ArcticDB symbol named `SYM__vintages` and records, per vintag
 The protocol is deliberately two-step:
 
 1. Write the data to ArcticDB (returns an integer version).
-2. **Append a row to the vintage index.** This append is the atomic **commit point**.
+2. **Append a row to the vintage index** (`_append_vintage_index`). This per-symbol write
+   is the atomic **commit point**.
 
 If the process crashes between the two steps, the data version exists but is not
 referenced by the index — an **orphan**. All correctness-critical reads resolve against
 the committed index only, so an orphan is invisible to readers and is later removed by
 `reconcile_orphans` (see [Operations](./operations.md)).
 
-A best-effort ArcticDB snapshot is also taken per commit purely for UI convenience;
-correctness never depends on it.
+A best-effort ArcticDB snapshot is also taken per commit (named
+`{symbol}@{as_of}` at microsecond resolution) purely for UI convenience; correctness never
+depends on it, and the call is wrapped so a snapshot failure cannot fail a commit.
 
 ## Reading: `read_as_of`
 
@@ -98,28 +145,32 @@ df = read_as_of(lib, symbol, as_of="2026-05-15", date_range=(lo, hi))
 Resolution rules:
 
 - **Degenerate symbols** filter on knowledge time directly: rows where `fetched_at` is at
-  or before the requested `as_of`.
-- **Bitemporal symbols** re-read the vintage index on every call and select the vintage
+  or before the requested `as_of` (never `valid_time`).
+- **Bitemporal symbols** re-read the vintage index on *every* call and select the vintage
   with the greatest `as_of` that is at or before the requested one. With no `as_of`, the
-  latest committed vintage is used (never an orphan write version). If the requested
-  `as_of` precedes the earliest vintage, the result is empty.
+  latest committed vintage is used (`_latest_committed_version`, never an orphan write
+  version). If the requested `as_of` precedes the earliest vintage, the result is empty
+  (an empty frame with the right columns).
 
-This is what makes a backtest honest: ask for `as_of` = your decision date, and you get
-exactly what was knowable then.
+This is the same point-in-time contract the [S2 read API](./frontend-integration.md)
+exposes: every data endpoint accepts an optional `as_of`, defaulting to the latest
+committed vintage.
 
 ## Curves
 
 `read_curve(commodity, as_of)` assembles a forward curve by reading each contract symbol
 (via `symbology.contracts_for`) at the requested knowledge time and concatenating the
-per-contract frames in contract order.
+per-contract frames in contract order. It is the engine behind the read API's `/curve`
+endpoint.
 
 ## The honesty flag, end to end
 
-`vintage_reconstructed` rides from the orchestration layer (which sets it based on how
-old the partition is) through `commit_vintage` into both the data frame and the vintage
-index. A reader can therefore tell, per vintage, whether it was a genuine forward capture
-or a backfilled reconstruction of already-revised data — and treat the two differently in
-a backtest.
+`vintage_reconstructed` rides from the orchestration layer (which sets it based on how old
+the partition is) through `commit_vintage` into both the data frame and the vintage index.
+True point-in-time history accrues only going *forward*; rows backfilled for already-revised
+periods are flagged `vintage_reconstructed=True`. A reader can therefore tell, per vintage,
+whether it was a genuine forward capture or a backfilled reconstruction — and treat the two
+differently in a backtest.
 
-See [Architecture](./architecture.md#the-bitemporal-model) for the conceptual model and
-[Orchestration](./orchestration.md) for where `reconstructed` is decided.
+See [Data Sources & Connectors](./data-sources-connectors.md) for what each series carries,
+and [Orchestration](./orchestration.md) for where `reconstructed` is decided.

--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -6,64 +6,93 @@ sidebar_label: Testing
 
 # Testing
 
-Energex is tested with `pytest`. The suite covers the pure core (connectors, storage,
-quality, symbology, config), the hexagonal boundary, and the Dagster wiring.
+Energex ships with **220+ `pytest` tests** that run **offline by default**. The suite covers
+the pure core (connectors, storage, quality gate, symbology, config), the hexagonal
+boundary, the S2 read API, and the Dagster wiring. No network, no MinIO, and no
+credentials are required to run it.
 
-## Prerequisites
+## The offline invariant
 
-- Python 3.10+
-- [`uv`](https://docs.astral.sh/uv/)
-- Internet access is **not** required: connector tests mock the HTTP layer with `respx`,
-  and storage tests run against a local ArcticDB.
+Three seams keep the suite hermetic:
+
+- **Connectors are mocked with `respx`.** Every source HTTP call (EIA-930, ERCOT, FRED,
+  EIA v2, NOAA, yfinance) is stubbed at the transport layer, so connector tests assert the
+  shape of the resulting `FetchResult` without ever touching the network.
+- **Storage runs on LMDB, not MinIO.** The `arctic_uri` fixture hands every storage test a
+  unique `lmdb://…` ArcticDB under pytest's `tmp_path`; the live MinIO/S3 backend is never
+  contacted.
+- **Dagster `Definitions` are validated via the CLI** — the orchestration layer is imported
+  and resolved without a running daemon or webserver.
+
+### No credentials, ever
+
+The suite must not read a developer's local `.env`. `tests/conftest.py` enforces this
+**before any `energex` import**:
+
+```python
+# tests/conftest.py
+os.environ["ENERGEX_SKIP_DOTENV"] = "1"
+```
+
+With `ENERGEX_SKIP_DOTENV=1`, config never loads the repo-root `.env`, so the offline
+no-credentials invariant holds regardless of what keys a developer has set locally. This is
+what lets the same tests run identically on a laptop and in CI.
+
+`conftest.py` also pins one load-order hazard: **`arcticdb` is imported before
+`pandas`/`pyarrow`** process-wide (an AWS-SDK symbol collision aborts the process on macOS
+otherwise). The import is guarded, so test jobs that don't install the `storage` extra can
+still collect their non-storage tests; the `arctic_*` fixtures only run when requested.
 
 ## Running the suite
 
 ```bash
 uv sync --all-extras                 # install the package with every extra
-uv run --all-extras pytest           # full suite (with coverage, per pyproject)
+uv run --all-extras pytest           # full suite (coverage on, per pyproject)
 uv run --all-extras pytest -q        # quiet
 uv run --all-extras pytest tests/test_storage_pointintime.py   # a single file
 ```
 
-`arcticdb` must be importable before `pandas`/`pyarrow` (a load-order hazard on macOS);
-`tests/conftest.py` already pins this for the whole suite.
+`addopts` in `pyproject.toml` turns on coverage by default
+(`--cov=energex --cov-report=term-missing`).
 
 ## What the suite covers
 
 | Area | Representative tests |
 | --- | --- |
-| **Hexagonal boundary** | `test_core_has_no_framework_imports`, `test_core_layout` |
-| **Storage & point-in-time** | `test_storage_pointintime`, `test_storage_roundtrip`, `test_storage_curve`, `test_latest_is_committed` |
+| **Hexagonal boundary** | core has zero `dagster` / `fastapi` / `langgraph` imports |
+| **Storage & point-in-time** | `test_storage_roundtrip`, `test_storage_pointintime`, `test_latest_is_committed` |
 | **Bitemporal invariants** | `test_pointintime_reverse_backfill`, `test_revision_merge_gap`, `test_write_bars_sparse` |
 | **Crash safety** | `test_crash_safety` (orphan write + `reconcile_orphans`) |
 | **Connectors** | `test_connector_eia`, `test_connector_fred`, `test_connector_weather`, `test_connector_yfinance` |
-| **Public API contract** | `test_api_contract` (the importable `energex` public surface, not a data-source connector) |
-| **Quality gate** | `test_pandera_schemas`, `test_quality`, `test_quality_collision` |
-| **Symbology** | `test_symbology` |
-| **Orchestration loads** | `test_definitions_load` (the Dagster `Definitions` import cleanly) |
+| **S2 read API** | `test_readapi` (FastAPI endpoint contract, `as_of`, auth, row caps) |
+| **Quality gate** | `test_pandera_schemas`, `test_quality_collision`, `test_exceptions` |
+| **Symbology** | `test_symbology` (`instrument_id` ↔ `(library, symbol, revision_mode)`) |
+| **Orchestration loads** | Dagster `Definitions` resolve via the `dagster` CLI |
 | **Configuration** | `test_config`, `test_core_config_settings` |
-| **Legacy analytics** | `test_volatility`, `test_futures`, `test_dated_futures`, `test_charts`, and others |
 
 ### The boundary test is load-bearing
 
-`test_core_has_no_framework_imports` is the executable form of the architecture rule: it
-walks every file under `src/energex/core` and fails if any imports `dagster`, `fastapi`,
-or `langgraph`. If you accidentally pull a framework into the core, the build goes red.
-See [Architecture](./architecture.md#the-core-is-framework-agnostic-and-ci-enforces-it).
+The architecture rule — `energex.core` imports no framework — is enforced as an executable
+test: it walks every file under `src/energex/core` and fails if any imports `dagster`,
+`fastapi`, or `langgraph`. Pull a framework into the core and the build goes red. See
+[Architecture](./architecture.md).
 
 ### Connector tests
 
 Connector tests use `respx` to stub the source API and assert the shape of the resulting
-`FetchResult`: the normalized columns (`instrument_id`, tz-aware-UTC `valid_time`,
-`value`), the provenance fields, and `complete_over_range`. No network calls are made.
+`FetchResult`: the normalized columns (`instrument_id`, tz-aware-UTC `valid_time`, value
+columns), the provenance fields (`source`, `fetched_at`, `source_url`), and
+`complete_over_range`. No network calls are made. See
+[Data Sources & Connectors](./data-sources-connectors.md).
 
 ### Point-in-time and crash-safety tests
 
-These are the most important tests in the project, because they protect the core
-invariant. They assert that `read_as_of` never leaks the future, that a reverse backfill
-flags `vintage_reconstructed`, that inline revisions merge by exact `valid_time` without
-dropping prior rows, and that an orphaned write (a crash between data write and index
-append) is invisible to readers and removed by `reconcile_orphans`.
+These protect the core bitemporal invariant and are the most important tests in the
+project. They assert that `read_as_of` never leaks the future, that a reverse backfill flags
+`vintage_reconstructed`, that inline revisions merge by exact `valid_time` without dropping
+prior rows, and that an orphaned write (a crash between data write and index append) is
+invisible to readers and removed by `reconcile_orphans`. See
+[Storage & Point-in-Time](./storage-point-in-time.md).
 
 ## Linting and formatting
 
@@ -72,18 +101,47 @@ uv run --all-extras ruff check src/energex tests
 uv run --all-extras ruff format --check src/energex tests
 ```
 
-Install the pre-commit hooks to run these on every commit:
+Ruff is configured in `pyproject.toml` (line length 100; rule sets `E`, `F`, `W`, `I`, `N`,
+`UP`, `B`, `A`, `C4`, `T20`). Install the pre-commit hooks to run these on every commit:
 
 ```bash
 uv run pre-commit install
 ```
 
+## CI gates
+
+`.github/workflows/ci.yml` runs on every push to `main` and every pull request. A green
+checkout must satisfy all of these jobs:
+
+| Job | What it gates |
+| --- | --- |
+| **Test (pytest)** | Full suite on Python **3.11 and 3.12** (matrix, `fail-fast: false`) |
+| **Lint (ruff)** | `ruff check` and `ruff format --check` over `src/energex` and `tests` |
+| **Bitemporal storage gate** | The point-in-time / crash-safety / symbology suite on offline LMDB ArcticDB |
+| **Pandera quality gate** | `test_pandera_schemas`, `test_quality_collision`, `test_exceptions` |
+| **Connector contract gate** | The `respx`-mocked connector tests plus `test_readapi` |
+| **Secret scan (gitleaks)** | `gitleaks detect` against `.gitleaks.toml` (redacted) |
+| **Docker build** | Builds the image (PRs build-only; push to `main` builds and pushes to GHCR) |
+| **Type-check (mypy, advisory)** | `mypy src/energex`, **non-blocking** — emits a warning, never fails the build |
+
+The named gates re-run focused slices of the suite with the minimal extras they need
+(`--extra storage`, `--extra quality`, `--extra service`, `--extra dev`), so a regression in
+the bitemporal store, the pandera schemas, or the connector contract surfaces as its own red
+check rather than buried in the full run.
+
+mypy is **advisory only**: the strict-mypy backlog is being cleared progressively, so the
+job emits `::warning::` on errors instead of failing. It flips to a hard gate once clean.
+
 ## Continuous verification
 
-A green checkout should satisfy all of:
+Reproduce the CI gates locally before pushing:
 
-- `uv run --all-extras pytest` — the full suite passes.
-- `uv run --all-extras ruff check src/energex tests` — no lint errors.
-- `uv build` — the wheel builds.
-- The Dagster definitions import (`test_definitions_load`), proving the orchestration
-  layer is wired and loadable.
+```bash
+uv run --all-extras pytest                                   # full suite (3.11/3.12 in CI)
+uv run --all-extras ruff check src/energex tests             # lint
+uv run --all-extras ruff format --check src/energex tests    # format
+docker build -t energex:local .                              # image builds
+```
+
+See [Deployment](./deployment.md) for what the Docker image runs in production and
+[Orchestration](./orchestration.md) for the Dagster assets the suite validates.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,7 +6,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'Energex',
-  tagline: 'A bitemporal energy-market data platform',
+  tagline: 'A bitemporal, point-in-time data platform for power markets',
   favicon: 'img/favicon.ico',
 
   future: {
@@ -14,7 +14,8 @@ const config: Config = {
   },
 
   url: 'https://oldhero5.github.io',
-  baseUrl: '/',
+  // Project Pages site: served at https://oldhero5.github.io/energex/
+  baseUrl: '/energex/',
 
   organizationName: 'oldhero5',
   projectName: 'energex',


### PR DESCRIPTION
Redoes the entire documentation site to match the current platform and sets up publishing.

## What changed
- **All 11 Docusaurus pages rewritten** to the current reality (10 via a parallel rewrite pass against a shared ground-truth brief + the live code; architecture.md by hand): power-markets focus (EIA-930 across all ~65–73 balancing authorities + ERCOT real-time/day-ahead SPP and system load), the **live S2 read API**, the bitemporal ArcticDB model, the operating-day-aware Dagster schedules, and content-idempotent storage. The old docs predated the power pivot and described the S2 API as "reserved" with invented endpoints.
- **Docusaurus config**: fixed `baseUrl` to the project-pages path `/energex/` and refreshed the tagline.
- **Publishing**: added `.github/workflows/docs.yml` that builds the site and deploys it to **GitHub Pages** (source = GitHub Actions) on every push to `main` that touches `website/**`. Pages is enabled; the site will live at https://oldhero5.github.io/energex/.
- Repo **About** + homepage updated separately (the old description still referenced the removed DuckDB futures library).

The site builds clean (`npm run build`, strict broken-link check passes).